### PR TITLE
This adds some enhancements to the readStyle functionality

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,8 @@
       "name": "Debug Jest Tests Windows",
       "program": "${workspaceRoot}/node_modules/jest/bin/jest",
       "args": [
-        "-i"
+        "-i",
+        "--watch"
       ],
       "internalConsoleOptions": "openOnSessionStart",
       "console": "integratedTerminal",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,20 @@
       ],
       "runtimeExecutable": null,
       "console": "integratedTerminal"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Jest Tests Windows",
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest",
+      "args": [
+        "-i"
+      ],
+      "internalConsoleOptions": "openOnSessionStart",
+      "console": "integratedTerminal",
+      "outFiles": [
+        "${workspaceRoot}/build/dist/**/*"
+      ]
     }
   ]
 }

--- a/data/styles/line_simpleline.ts
+++ b/data/styles/line_simpleline.ts
@@ -1,0 +1,16 @@
+import { Style } from 'geostyler-style';
+
+const lineSimpleLine: Style = {
+  type: 'Line',
+  rules: [
+    {
+      symbolizer: {
+        kind: 'Line',
+        color: '#000000',
+        width: 3
+      }
+    }
+  ]
+};
+
+export default lineSimpleLine;

--- a/data/styles/point_simplepoint.ts
+++ b/data/styles/point_simplepoint.ts
@@ -1,0 +1,16 @@
+import { Style } from 'geostyler-style';
+
+const pointSimplePoint: Style = {
+  type: 'Point',
+  rules: [
+    {
+      symbolizer: {
+        kind: 'Circle',
+        color: '#FF0000',
+        radius: 6
+      }
+    }
+  ]
+};
+
+export default pointSimplePoint;

--- a/data/styles/point_simplepoint_filter.ts
+++ b/data/styles/point_simplepoint_filter.ts
@@ -1,0 +1,28 @@
+import { Style } from 'geostyler-style';
+
+const pointSimplePoint: Style = {
+  type: 'Point',
+  rules: [
+    {
+      filter: ['&&',
+        ['=', 'NAME', 'New York'],
+        ['Not',
+          ['>', 'POPULATION', 100000]
+        ]
+      ],
+      scaleDenominator: {
+        min: 10000,
+        max: 20000
+      },
+      symbolizer: {
+        kind: 'Circle',
+        color: '#FF0000',
+        radius: 6,
+        strokeColor: '#000000',
+        strokeWidth: 2
+      }
+    }
+  ]
+};
+
+export default pointSimplePoint;

--- a/data/styles/point_styledlabel.ts
+++ b/data/styles/point_styledlabel.ts
@@ -1,0 +1,19 @@
+import { Style } from 'geostyler-style';
+
+const pointStyledLabel: Style = {
+  type: 'Point',
+  rules: [
+    {
+      symbolizer: {
+        kind: 'Text',
+        color: '#000000',
+        field: 'name',
+        font: ['Arial'],
+        size: 12,
+        offset: [0, 5]
+      }
+    }
+  ]
+};
+
+export default pointStyledLabel;

--- a/data/styles/polygon_transparentpolygon.ts
+++ b/data/styles/polygon_transparentpolygon.ts
@@ -1,0 +1,17 @@
+import { Style } from 'geostyler-style';
+
+const polygonTransparentPolygon: Style = {
+  type: 'Fill',
+  rules: [
+    {
+      symbolizer: {
+        kind: 'Fill',
+        color: '#000080',
+        opacity: 0.5,
+        outlineColor: '#FFFFFF'
+      }
+    }
+  ]
+};
+
+export default polygonTransparentPolygon;

--- a/src/SldStyleParser.spec.ts
+++ b/src/SldStyleParser.spec.ts
@@ -5,6 +5,7 @@ import { Style } from 'geostyler-style';
 import point_simplepoint from '../data/styles/point_simplepoint';
 import line_simpleline from '../data/styles/line_simpleline';
 import polygon_transparentpolygon from '../data/styles/polygon_transparentpolygon';
+import point_styledlabel from '../data/styles/point_styledlabel';
 
 it('SldStyleParser is defined', () => {
   expect(SldStyleParser).toBeDefined();
@@ -49,11 +50,12 @@ describe('SldStyleParser implements StyleParser', () => {
         });
     });
     it('can read a SLD TextSymbolizer', () => {
-      expect.assertions(1);
+      expect.assertions(2);
       const sld = fs.readFileSync( './data/slds/point_styledlabel.sld', 'utf8');
       return styleParser.readStyle(sld)
         .then((geoStylerStyle: Style) => {
           expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(point_styledlabel);
         });
     });
     it('can read a SLD style with a filter', () => {

--- a/src/SldStyleParser.spec.ts
+++ b/src/SldStyleParser.spec.ts
@@ -6,6 +6,7 @@ import point_simplepoint from '../data/styles/point_simplepoint';
 import line_simpleline from '../data/styles/line_simpleline';
 import polygon_transparentpolygon from '../data/styles/polygon_transparentpolygon';
 import point_styledlabel from '../data/styles/point_styledlabel';
+import point_simplepoint_filter from '../data/styles/point_simplepoint_filter';
 
 it('SldStyleParser is defined', () => {
   expect(SldStyleParser).toBeDefined();
@@ -59,11 +60,12 @@ describe('SldStyleParser implements StyleParser', () => {
         });
     });
     it('can read a SLD style with a filter', () => {
-      expect.assertions(1);
+      expect.assertions(2);
       const sld = fs.readFileSync( './data/slds/point_simplepoint_filter.sld', 'utf8');
       return styleParser.readStyle(sld)
         .then((geoStylerStyle: Style) => {
           expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(point_simplepoint_filter);
         });
     });
   });

--- a/src/SldStyleParser.spec.ts
+++ b/src/SldStyleParser.spec.ts
@@ -4,6 +4,7 @@ import { Style } from 'geostyler-style';
 
 import point_simplepoint from '../data/styles/point_simplepoint';
 import line_simpleline from '../data/styles/line_simpleline';
+import polygon_transparentpolygon from '../data/styles/polygon_transparentpolygon';
 
 it('SldStyleParser is defined', () => {
   expect(SldStyleParser).toBeDefined();
@@ -39,11 +40,12 @@ describe('SldStyleParser implements StyleParser', () => {
       });
     });
     it('can read a SLD PolygonSymbolizer', () => {
-      expect.assertions(1);
+      expect.assertions(2);
       const sld = fs.readFileSync( './data/slds/polygon_transparentpolygon.sld', 'utf8');
       return styleParser.readStyle(sld)
-        .then((geoStylerStyle: Style) => {
-          expect(geoStylerStyle).toBeDefined();
+      .then((geoStylerStyle: Style) => {
+        expect(geoStylerStyle).toBeDefined();
+        expect(geoStylerStyle).toEqual(polygon_transparentpolygon);
         });
     });
     it('can read a SLD TextSymbolizer', () => {

--- a/src/SldStyleParser.spec.ts
+++ b/src/SldStyleParser.spec.ts
@@ -2,6 +2,8 @@ import * as fs from 'fs';
 import SldStyleParser from './SldStyleParser';
 import { Style } from 'geostyler-style';
 
+import point_simplepoint from '../data/styles/point_simplepoint';
+
 it('SldStyleParser is defined', () => {
   expect(SldStyleParser).toBeDefined();
 });
@@ -18,11 +20,12 @@ describe('SldStyleParser implements StyleParser', () => {
       expect(styleParser.readStyle).toBeDefined();
     });
     it('can read a SLD PointSymbolizer', () => {
-      expect.assertions(1);
+      expect.assertions(2);
       const sld = fs.readFileSync( './data/slds/point_simplepoint.sld', 'utf8');
       return styleParser.readStyle(sld)
         .then((geoStylerStyle: Style) => {
           expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(point_simplepoint);
         });
     });
     it('can read a SLD LineSymbolizer', () => {

--- a/src/SldStyleParser.spec.ts
+++ b/src/SldStyleParser.spec.ts
@@ -3,6 +3,7 @@ import SldStyleParser from './SldStyleParser';
 import { Style } from 'geostyler-style';
 
 import point_simplepoint from '../data/styles/point_simplepoint';
+import line_simpleline from '../data/styles/line_simpleline';
 
 it('SldStyleParser is defined', () => {
   expect(SldStyleParser).toBeDefined();
@@ -27,14 +28,15 @@ describe('SldStyleParser implements StyleParser', () => {
           expect(geoStylerStyle).toBeDefined();
           expect(geoStylerStyle).toEqual(point_simplepoint);
         });
-    });
+      });
     it('can read a SLD LineSymbolizer', () => {
-      expect.assertions(1);
+      expect.assertions(2);
       const sld = fs.readFileSync( './data/slds/line_simpleline.sld', 'utf8');
       return styleParser.readStyle(sld)
-        .then((geoStylerStyle: Style) => {
-          expect(geoStylerStyle).toBeDefined();
-        });
+      .then((geoStylerStyle: Style) => {
+        expect(geoStylerStyle).toBeDefined();
+        expect(geoStylerStyle).toEqual(line_simpleline);
+      });
     });
     it('can read a SLD PolygonSymbolizer', () => {
       expect.assertions(1);

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -73,8 +73,20 @@ class SldStyleParser implements StyleParser {
     const foundSymbolizers = symbolizers.filter(symb => {
       return dom.getElementsByTagName(symb).length > 0;
     });
-    const symbolizer = foundSymbolizers[0].replace('Symbolizer', '');
-    styleType = symbolizer === 'Text' ? 'Point' : <StyleType> symbolizer;
+    switch (foundSymbolizers[0]) {
+      case 'PointSymbolizer':
+      case 'TextSymbolizer':
+        styleType = 'Point';
+        break;
+      case 'PolygonSymbolizer':
+        styleType = 'Fill';
+        break;
+      case 'LineSymbolizer':
+        styleType = 'Line';
+        break;
+      default:
+        throw new Error('StyleType could not be detected');
+    }
     return styleType;
   }
 
@@ -316,7 +328,7 @@ class SldStyleParser implements StyleParser {
           fillSymbolizer.color = value;
           break;
         case 'fill-opacity':
-          fillSymbolizer.opacity = value;
+          fillSymbolizer.opacity = parseFloat(value);
           break;
         default:
           break;

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -359,8 +359,10 @@ class SldStyleParser implements StyleParser {
       kind: 'Text'
     };
     const fontCssParameters = _get(sldSymbolizer, 'Font[0].CssParameter') || [];
-    textSymbolizer.field = _get(sldSymbolizer, 'Label[0].PropertyName[0]');
-    textSymbolizer.color = _get(sldSymbolizer, 'Fill[0].CssParameter[0]._');
+    const field = _get(sldSymbolizer, 'Label[0].PropertyName[0]');
+    const color = _get(sldSymbolizer, 'Fill[0].CssParameter[0]._');
+    if (field) { textSymbolizer.field = field; }
+    if (color) { textSymbolizer.color = color; }
     const displacement = _get(sldSymbolizer, 'LabelPlacement[0].PointPlacement[0].Displacement[0]');
     if (displacement) {
       const x = displacement.DisplacementX[0];
@@ -379,7 +381,7 @@ class SldStyleParser implements StyleParser {
       } = cssParameter;
       switch (name) {
         case 'font-family':
-          textSymbolizer.font = value;
+          textSymbolizer.font = [value];
           break;
         case 'font-style':
           // Currently not supported by GeoStyler Style

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -226,9 +226,15 @@ class SldStyleParser implements StyleParser {
       const opacity = _get(sldSymbolizer, 'Graphic[0].Opacity[0]');
       const radius = _get(sldSymbolizer, 'Graphic[0].Size[0]');
       const color = _get(sldSymbolizer, 'Graphic[0].Mark[0].Fill[0].CssParameter[0]._');
-      if (opacity) { circleSymbolizer.opacity = opacity; }
-      if (radius) { circleSymbolizer.radius = parseFloat(radius); }
-      if (color ) { circleSymbolizer.color = color; }
+      if (opacity) {
+        circleSymbolizer.opacity = opacity;
+      }
+      if (radius) {
+        circleSymbolizer.radius = parseFloat(radius);
+      }
+      if (color ) {
+        circleSymbolizer.color = color;
+      }
       strokeParams.forEach((param: any) => {
         switch (param.$.name) {
           case 'stroke':
@@ -250,8 +256,12 @@ class SldStyleParser implements StyleParser {
       };
       const opacity = _get(sldSymbolizer, 'Graphic[0].Opacity[0]');
       const size = _get(sldSymbolizer, 'Graphic[0].Size[0]');
-      if (opacity) { iconSymbolizer.opacity = opacity; }
-      if (size) { iconSymbolizer.size = size; }
+      if (opacity) {
+        iconSymbolizer.opacity = opacity;
+      }
+      if (size) {
+        iconSymbolizer.size = size;
+      }
       pointSymbolizer = iconSymbolizer;
     } else {
       throw new Error(`PointSymbolizer can not be parsed. Only "circle" is supported
@@ -373,8 +383,12 @@ class SldStyleParser implements StyleParser {
     const fontCssParameters = _get(sldSymbolizer, 'Font[0].CssParameter') || [];
     const field = _get(sldSymbolizer, 'Label[0].PropertyName[0]');
     const color = _get(sldSymbolizer, 'Fill[0].CssParameter[0]._');
-    if (field) { textSymbolizer.field = field; }
-    if (color) { textSymbolizer.color = color; }
+    if (field) {
+      textSymbolizer.field = field;
+    }
+    if (color) {
+      textSymbolizer.color = color;
+    }
     const displacement = _get(sldSymbolizer, 'LabelPlacement[0].PointPlacement[0].Displacement[0]');
     if (displacement) {
       const x = displacement.DisplacementX[0];
@@ -466,8 +480,12 @@ class SldStyleParser implements StyleParser {
             rule = {
               symbolizer
             };
-            if (filter) { rule.filter = filter; }
-            if (scaleDenominator) { rule.scaleDenominator = scaleDenominator; }
+            if (filter) {
+              rule.filter = filter;
+            }
+            if (scaleDenominator) {
+              rule.scaleDenominator = scaleDenominator;
+            }
             rules.push(rule);
           });
         });

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -25,6 +25,7 @@ import {
 } from 'xmldom';
 
 import {
+  isString as _isString,
   get as _get
 } from 'lodash';
 
@@ -120,7 +121,18 @@ class SldStyleParser implements StyleParser {
     if (Object.keys(comparisonMap).includes(sldOperatorName)) {
       const comparisonOperator: ComparisonOperator = comparisonMap[sldOperatorName];
       const property: string = sldFilter.PropertyName[0];
-      const value = sldOperatorName === 'PropertyIsNull' ? null : sldFilter.Literal[0];
+      let value = sldFilter.Literal[0];
+      if (sldOperatorName === 'PropertyIsNull') {
+        value = null;
+      }
+      if (!Number.isNaN(parseFloat(value))) {
+        value = parseFloat(value);
+      }
+      if (_isString(value)) {
+        const lowerValue = value.toLowerCase();
+        if (lowerValue === 'false') {value = false; }
+        if (lowerValue === 'true') {value = true; }
+      }
       filter =  [
         comparisonOperator,
         property,
@@ -223,7 +235,7 @@ class SldStyleParser implements StyleParser {
             circleSymbolizer.strokeColor = param._;
             break;
           case 'stroke-width':
-            circleSymbolizer.strokeWidth = param._;
+            circleSymbolizer.strokeWidth = parseFloat(param._);
             break;
           default:
             break;


### PR DESCRIPTION
This adds some enhancements to the `readStyle` method of the SLD parser.

Further on it ...
- Adds some example styles for the corresponding SLDs to give the tests much more value.
- Introduces a jest debug config for Windows