### PR TITLE
 Adapt parser to read and write name properties for Style and Rule

### DIFF
--- a/data/slds/line_simpleline.sld
+++ b/data/slds/line_simpleline.sld
@@ -8,7 +8,7 @@
   <NamedLayer>
     <Name>Simple Line</Name>
     <UserStyle>
-      <Title>SLD Cook Book: Simple Line</Title>
+      <Title>Simple Line</Title>
       <FeatureTypeStyle>
         <Rule>
           <LineSymbolizer>

--- a/data/slds/point_simplepoint.sld
+++ b/data/slds/point_simplepoint.sld
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<StyledLayerDescriptor version="1.0.0" 
-    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
-    xmlns="http://www.opengis.net/sld" 
-    xmlns:ogc="http://www.opengis.net/ogc" 
-    xmlns:xlink="http://www.w3.org/1999/xlink" 
+<StyledLayerDescriptor version="1.0.0"
+    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+    xmlns="http://www.opengis.net/sld"
+    xmlns:ogc="http://www.opengis.net/ogc"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <NamedLayer>
     <Name>Simple Point</Name>
     <UserStyle>
-      <Title>SLD Cook Book: Simple Point</Title>
+      <Title>Simple Point</Title>
       <FeatureTypeStyle>
         <Rule>
           <PointSymbolizer>

--- a/data/slds/point_simplepoint_filter.sld
+++ b/data/slds/point_simplepoint_filter.sld
@@ -8,9 +8,10 @@
   <NamedLayer>
     <Name>Simple Point Filter</Name>
     <UserStyle>
-      <Title>SLD Cook Book: Simple Point</Title>
+      <Title>Simple Point Filter</Title>
       <FeatureTypeStyle>
         <Rule>
+          <Name>Small populated New Yorks</Name>
           <MinScaleDenominator>10000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <ogc:Filter>

--- a/data/slds/point_styledlabel.sld
+++ b/data/slds/point_styledlabel.sld
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<StyledLayerDescriptor version="1.0.0" 
-    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
-    xmlns="http://www.opengis.net/sld" 
-    xmlns:ogc="http://www.opengis.net/ogc" 
-    xmlns:xlink="http://www.w3.org/1999/xlink" 
+<StyledLayerDescriptor version="1.0.0"
+    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+    xmlns="http://www.opengis.net/sld"
+    xmlns:ogc="http://www.opengis.net/ogc"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <NamedLayer>
-    <Name>Point with styled label</Name>
+    <Name>Styled Label</Name>
     <UserStyle>
-      <Title>GeoServer SLD Cook Book: Point with styled label</Title>
+      <Title>Styled Label</Title>
       <FeatureTypeStyle>
         <Rule>
           <TextSymbolizer>

--- a/data/slds/polygon_transparentpolygon.sld
+++ b/data/slds/polygon_transparentpolygon.sld
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<StyledLayerDescriptor version="1.0.0" 
-    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
-    xmlns="http://www.opengis.net/sld" 
-    xmlns:ogc="http://www.opengis.net/ogc" 
-    xmlns:xlink="http://www.w3.org/1999/xlink" 
+<StyledLayerDescriptor version="1.0.0"
+    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+    xmlns="http://www.opengis.net/sld"
+    xmlns:ogc="http://www.opengis.net/ogc"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <NamedLayer>
-    <Name>Transparent polygon</Name>
+    <Name>Transparent Polygon</Name>
     <UserStyle>
-      <Title>SLD Cook Book: Transparent polygon</Title>
+      <Title>Transparent Polygon</Title>
       <FeatureTypeStyle>
         <Rule>
           <PolygonSymbolizer>

--- a/data/styles/line_simpleline.ts
+++ b/data/styles/line_simpleline.ts
@@ -1,16 +1,16 @@
 import { Style } from 'geostyler-style';
 
 const lineSimpleLine: Style = {
+  name: 'Simple Line',
   type: 'Line',
-  rules: [
-    {
-      symbolizer: {
-        kind: 'Line',
-        color: '#000000',
-        width: 3
-      }
+  rules: [{
+    name: '',
+    symbolizer: {
+      kind: 'Line',
+      color: '#000000',
+      width: 3
     }
-  ]
+  }]
 };
 
 export default lineSimpleLine;

--- a/data/styles/point_simplepoint.ts
+++ b/data/styles/point_simplepoint.ts
@@ -1,16 +1,16 @@
 import { Style } from 'geostyler-style';
 
 const pointSimplePoint: Style = {
+  name: 'Simple Point',
   type: 'Point',
-  rules: [
-    {
-      symbolizer: {
-        kind: 'Circle',
-        color: '#FF0000',
-        radius: 6
-      }
+  rules: [{
+    name: '',
+    symbolizer: {
+      kind: 'Circle',
+      color: '#FF0000',
+      radius: 6
     }
-  ]
+  }]
 };
 
 export default pointSimplePoint;

--- a/data/styles/point_simplepoint_filter.ts
+++ b/data/styles/point_simplepoint_filter.ts
@@ -1,28 +1,28 @@
 import { Style } from 'geostyler-style';
 
 const pointSimplePoint: Style = {
+  name: 'Simple Point Filter',
   type: 'Point',
-  rules: [
-    {
-      filter: ['&&',
-        ['==', 'NAME', 'New York'],
-        ['!',
-          ['>', 'POPULATION', 100000]
-        ]
-      ],
-      scaleDenominator: {
-        min: 10000,
-        max: 20000
-      },
-      symbolizer: {
-        kind: 'Circle',
-        color: '#FF0000',
-        radius: 6,
-        strokeColor: '#000000',
-        strokeWidth: 2
-      }
+  rules: [{
+    name: 'Small populated New Yorks',
+    filter: ['&&',
+      ['==', 'NAME', 'New York'],
+      ['!',
+        ['>', 'POPULATION', 100000]
+      ]
+    ],
+    scaleDenominator: {
+      min: 10000,
+      max: 20000
+    },
+    symbolizer: {
+      kind: 'Circle',
+      color: '#FF0000',
+      radius: 6,
+      strokeColor: '#000000',
+      strokeWidth: 2
     }
-  ]
+  }]
 };
 
 export default pointSimplePoint;

--- a/data/styles/point_styledlabel.ts
+++ b/data/styles/point_styledlabel.ts
@@ -1,19 +1,19 @@
 import { Style } from 'geostyler-style';
 
 const pointStyledLabel: Style = {
+  name: 'Styled Label',
   type: 'Point',
-  rules: [
-    {
-      symbolizer: {
-        kind: 'Text',
-        color: '#000000',
-        field: 'name',
-        font: ['Arial'],
-        size: 12,
-        offset: [0, 5]
-      }
+  rules: [{
+    name: '',
+    symbolizer: {
+      kind: 'Text',
+      color: '#000000',
+      field: 'name',
+      font: ['Arial'],
+      size: 12,
+      offset: [0, 5]
     }
-  ]
+  }]
 };
 
 export default pointStyledLabel;

--- a/data/styles/polygon_transparentpolygon.ts
+++ b/data/styles/polygon_transparentpolygon.ts
@@ -1,17 +1,17 @@
 import { Style } from 'geostyler-style';
 
 const polygonTransparentPolygon: Style = {
+  name: 'Transparent Polygon',
   type: 'Fill',
-  rules: [
-    {
-      symbolizer: {
-        kind: 'Fill',
-        color: '#000080',
-        opacity: 0.5,
-        outlineColor: '#FFFFFF'
-      }
+  rules: [{
+    name: '',
+    symbolizer: {
+      kind: 'Fill',
+      color: '#000080',
+      opacity: 0.5,
+      outlineColor: '#FFFFFF'
     }
-  ]
+  }]
 };
 
 export default polygonTransparentPolygon;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2706,9 +2706,9 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "geostyler-style": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-0.2.0.tgz",
-      "integrity": "sha512-92ebHYtFxFG9/LenXJe8vhVrYOvaaoTmNLIlr9QrmFaoCKPqZIHj1QIquqDbiKdXjJDn4/a1hvV79LdE5GwQCA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-0.3.0.tgz",
+      "integrity": "sha512-HnaFNvKDYZeSSOyIj2nZ+J47Ghz/hl/jrMyhD3kFmBBySH8QVznJ+MDNFwDzcriZ6Kl/yhkLSOFFPhqNic6Dsw==",
       "requires": {
         "@types/jest": "22.2.3",
         "@types/node": "9.6.5",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@types/lodash": "4.14.108",
     "@types/xml2js": "0.4.2",
-    "geostyler-style": "0.2.0",
+    "geostyler-style": "0.3.0",
     "lodash": "4.17.10",
     "xml2js": "0.4.19",
     "xmldom": "0.1.27"


### PR DESCRIPTION
This adds read and write logic for parsing the name property for GeoStyler Style `Style` and `Rule`.