### PR TITLE
This fixes the build / the wrong main reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "xmldom": "0.1.27"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.build.json",
     "pretest": "npm run lint",
     "test": "jest",
     "lint": "tslint --project tsconfig.json --config tslint.json",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,34 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "build/dist",
+    "module": "commonjs",
+    "target": "es5",
+    "lib": [
+      "dom",
+      "es2017"
+    ],
+    "sourceMap": true,
+    "allowJs": true,
+    "moduleResolution": "node",
+    "rootDir": "src",
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "suppressImplicitAnyIndexErrors": true,
+    "noUnusedLocals": true
+  },
+  "exclude": [
+    "node_modules",
+    "build",
+    "scripts",
+    "acceptance-tests",
+    "webpack",
+    "jest",
+    "data",
+    "**/*.spec.ts",
+    "coverage"
+  ]
+}


### PR DESCRIPTION
This fixes the build or the wrong name reference by adding a separate `tsconfig.build.json` with more specific excludes.

Fixes: https://github.com/terrestris/geostyler/issues/106