### PR TITLE
Added support for ExternalGraphic in PointSymbolizer

### DIFF
--- a/data/slds/point_externalgraphic.sld
+++ b/data/slds/point_externalgraphic.sld
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0"
+    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+    xmlns="http://www.opengis.net/sld"
+    xmlns:ogc="http://www.opengis.net/ogc"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NamedLayer>
+    <Name>External Graphic</Name>
+    <UserStyle>
+      <Title>External Graphic</Title>
+      <FeatureTypeStyle>
+        <Rule>
+          <PointSymbolizer>
+              <Graphic>
+                  <ExternalGraphic>
+                      <OnlineResource xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://geoserver.org/img/geoserver-logo.png" />
+                      <Format>image/png</Format>
+                  </ExternalGraphic>
+                  <Size>10</Size>
+                  <Rotation>90</Rotation>
+              </Graphic>
+          </PointSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/data/styles/point_externalgraphic.ts
+++ b/data/styles/point_externalgraphic.ts
@@ -1,0 +1,17 @@
+import { Style } from 'geostyler-style';
+
+const pointExternalGraphic: Style = {
+  name: 'External Graphic',
+  type: 'Point',
+  rules: [{
+    name: '',
+    symbolizer: {
+      kind: 'Icon',
+      image: 'http://geoserver.org/img/geoserver-logo.png',
+      size: 10,
+      rotate: 90
+    }
+  }]
+};
+
+export default pointExternalGraphic;

--- a/data/xml2jsObjects/point_externalgraphic.json
+++ b/data/xml2jsObjects/point_externalgraphic.json
@@ -1,0 +1,48 @@
+{
+  "StyledLayerDescriptor": {
+    "$": {
+      "version": "1.0.0",
+      "xsi:schemaLocation": "http://www.opengis.net/sld StyledLayerDescriptor.xsd",
+      "xmlns": "http://www.opengis.net/sld",
+      "xmlns:ogc": "http://www.opengis.net/ogc",
+      "xmlns:xlink": "http://www.w3.org/1999/xlink",
+      "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance"
+    },
+    "NamedLayer": [{
+      "Name": [
+        "External Graphic"
+      ],
+      "UserStyle": [{
+        "Title": [
+          "External Graphic"
+        ],
+        "FeatureTypeStyle": [{
+          "Rule": [{
+            "PointSymbolizer": [{
+              "Graphic": [{
+                "ExternalGraphic": [{
+                  "OnlineResource": [{
+                    "$": {
+                      "xlink:type": "simple",
+                      "xmlns:xlink": "http://www.w3.org/1999/xlink",
+                      "xlink:href": "http://geoserver.org/img/geoserver-logo.png"
+                    }
+                  }],
+                  "Format": [
+                    "image/png"
+                  ]
+                }],
+                "Size": [
+                  "10"
+                ],
+                "Rotation": [
+                  "10"
+                ]
+              }]
+            }]
+          }]
+        }]
+      }]
+    }]
+  }
+}

--- a/src/SldStyleParser.spec.ts
+++ b/src/SldStyleParser.spec.ts
@@ -7,6 +7,7 @@ import line_simpleline from '../data/styles/line_simpleline';
 import polygon_transparentpolygon from '../data/styles/polygon_transparentpolygon';
 import point_styledlabel from '../data/styles/point_styledlabel';
 import point_simplepoint_filter from '../data/styles/point_simplepoint_filter';
+import point_externalgraphic from '../data/styles/point_externalgraphic';
 
 it('SldStyleParser is defined', () => {
   expect(SldStyleParser).toBeDefined();
@@ -43,6 +44,15 @@ describe('SldStyleParser implements StyleParser', () => {
         .then((geoStylerStyle: Style) => {
           expect(geoStylerStyle).toBeDefined();
           expect(geoStylerStyle).toEqual(point_simplepoint);
+        });
+      });
+    it('can read a SLD PointSymbolizer with ExternalGraphic', () => {
+      expect.assertions(2);
+      const sld = fs.readFileSync( './data/slds/point_externalgraphic.sld', 'utf8');
+      return styleParser.readStyle(sld)
+        .then((geoStylerStyle: Style) => {
+          expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(point_externalgraphic);
         });
       });
     it('can read a SLD LineSymbolizer', () => {
@@ -163,6 +173,19 @@ describe('SldStyleParser implements StyleParser', () => {
           return styleParser.readStyle(sldString)
             .then(readStyle => {
               expect(readStyle).toEqual(point_simplepoint);
+            });
+        });
+    });
+    it('can write a SLD PointSymbolizer with ExternalGraphic', () => {
+      expect.assertions(2);
+      return styleParser.writeStyle(point_externalgraphic)
+        .then((sldString: string) => {
+          expect(sldString).toBeDefined();
+          // As string comparison between to XML-Strings is awkward and nonesens
+          // we read it again and compare the json input with the parser output
+          return styleParser.readStyle(sldString)
+            .then(readStyle => {
+              expect(readStyle).toEqual(point_externalgraphic);
             });
         });
     });


### PR DESCRIPTION
For the moment, the `format` parameter of externalgraphics is hardcoded, see issue https://github.com/terrestris/geostyler/issues/122