### PR TITLE
Fix creation of Filter elements that have the same type

### DIFF
--- a/data/slds/point_simplepoint_filter.sld
+++ b/data/slds/point_simplepoint_filter.sld
@@ -25,6 +25,10 @@
                 <PropertyName>TEST2</PropertyName>
                 <Literal>*York*</Literal>
               </PropertyIsLike>
+              <PropertyIsLike wildCard="*" singleChar="." escape="!">
+                <PropertyName>TEST1</PropertyName>
+                <Literal>*New*</Literal>
+              </PropertyIsLike>
               <Not>
                 <PropertyIsGreaterThan>
                   <PropertyName>POPULATION</PropertyName>

--- a/data/styles/point_simplepoint_filter.ts
+++ b/data/styles/point_simplepoint_filter.ts
@@ -7,6 +7,7 @@ const pointSimplePoint: Style = {
       ['==', 'NAME', 'New York'],
       ['==', 'TEST', null],
       ['*=', 'TEST2', '*York*'],
+      ['*=', 'TEST1', '*New*'],
       ['!', ['>', 'POPULATION', 100000]],
       ['||',
         ['==', 'TEST2', 1],

--- a/data/xml2jsObjects/point_simplepoint_filter.json
+++ b/data/xml2jsObjects/point_simplepoint_filter.json
@@ -35,6 +35,14 @@
                   },
                   "PropertyName": ["TEST2"],
                   "Literal": ["*York*"]
+                }, {
+                  "$": {
+                    "wildCard": "*",
+                    "singleChar": ".",
+                    "escape": "!"
+                  },
+                  "PropertyName": ["TEST1"],
+                  "Literal": ["*New*"]
                 }],
                 "Not": [{
                   "PropertyIsGreaterThan": [{

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -1049,7 +1049,11 @@ class SldStyleParser implements StyleParser {
             }
           });
         } else {
-          sldFilter[combinator][0][filterName] = sldSubFilter[filterName];
+          if (Array.isArray(sldFilter[combinator][0][filterName])) {
+            sldFilter[combinator][0][filterName].push(sldSubFilter[filterName][0]);
+          } else {
+            sldFilter[combinator][0][filterName] = sldSubFilter[filterName];
+          }
         }
       });
     } else if (Object.values(SldStyleParser.negationOperatorMap).includes(operator)) {


### PR DESCRIPTION
Until now, the last provided comparison operator was written to filter XML (only if it is not nested in a logical operator). This PR fixes this on order to create filters e.g. having multiple `PropertyIsLike` checks:

```
<And>
   <PropertyIsLike wildCard="*" singleChar="." escape="!">
      <PropertyName>TEST2</PropertyName>
      <Literal>*York*</Literal>
   </PropertyIsLike>
   <PropertyIsLike wildCard="*" singleChar="." escape="!">
      <PropertyName>TEST1</PropertyName>
      <Literal>*New*</Literal>
   </PropertyIsLike>
...
</And>
```