### PR TITLE
Fix use case for filters with deeply nested logical operations

### DIFF
--- a/data/slds/point_simplepoint_nestedLogicalFilters.sld
+++ b/data/slds/point_simplepoint_nestedLogicalFilters.sld
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0"
+    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+    xmlns="http://www.opengis.net/sld"
+    xmlns:ogc="http://www.opengis.net/ogc"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NamedLayer>
+    <Name>Simple Point Filter</Name>
+    <UserStyle>
+      <Title>Simple Point Filter</Title>
+      <FeatureTypeStyle>
+        <Rule>
+          <Name>Test</Name>
+          <Filter xmlns="http://www.opengis.net/ogc">
+            <And>
+              <Or>
+                <PropertyIsEqualTo>
+                  <PropertyName>ID</PropertyName>
+                  <Literal>1</Literal>
+                </PropertyIsEqualTo>
+                <PropertyIsEqualTo>
+                  <PropertyName>ID</PropertyName>
+                  <Literal>2</Literal>
+                </PropertyIsEqualTo>
+              </Or>
+              <Or>
+                <PropertyIsEqualTo>
+                  <PropertyName>STREET</PropertyName>
+                  <Literal>Main</Literal>
+                </PropertyIsEqualTo>
+                <PropertyIsEqualTo>
+                  <PropertyName>STREET</PropertyName>
+                  <Literal>Time square</Literal>
+                </PropertyIsEqualTo>
+                <And>
+                  <PropertyIsGreaterThanOrEqualTo>
+                    <PropertyName>HOUSENO</PropertyName>
+                    <Literal>1909</Literal>
+                  </PropertyIsGreaterThanOrEqualTo>
+                  <PropertyIsLessThanOrEqualTo>
+                    <PropertyName>HOUSENO</PropertyName>
+                    <Literal>19909</Literal>
+                  </PropertyIsLessThanOrEqualTo>
+                </And>
+              </Or>
+            </And>
+          </Filter>
+          <MinScaleDenominator>10000</MinScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
+          <PointSymbolizer>
+            <Graphic>
+              <Mark>
+                <WellKnownName>circle</WellKnownName>
+                <Fill>
+                   <CssParameter name="fill">#FF0000</CssParameter>
+                </Fill>
+                <Stroke>
+                   <CssParameter name="stroke">#000000</CssParameter>
+                   <CssParameter name="stroke-width">2</CssParameter>
+                </Stroke>
+              </Mark>
+              <Size>6</Size>
+            </Graphic>
+          </PointSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/data/styles/point_simplepoint_nestedLogicalFilters.ts
+++ b/data/styles/point_simplepoint_nestedLogicalFilters.ts
@@ -1,0 +1,36 @@
+import { Style } from 'geostyler-style';
+
+const pointSimplePoint: Style = {
+  'name': 'Simple Point Filter',
+  'rules': [{
+    'filter': ['&&',
+      ['||',
+        ['==', 'ID', 1],
+        ['==', 'ID', 2]
+      ],
+      ['||',
+        ['==', 'STREET', 'Main'],
+        ['==', 'STREET', 'Time square'],
+        ['&&',
+          ['>=', 'HOUSENO', 1909],
+          ['<=', 'HOUSENO', 19909]
+        ]
+      ]
+    ],
+    'name': 'Test',
+    'scaleDenominator': {
+      'max': 20000,
+      'min': 10000
+    },
+    'symbolizer': {
+      'color': '#FF0000',
+      'kind': 'Circle',
+      'radius': 6,
+      'strokeColor': '#000000',
+      'strokeWidth': 2
+    }
+  }],
+  'type': 'Point'
+};
+
+export default pointSimplePoint;

--- a/data/xml2jsObjects/point_simplepoint_nestedLogicalFilters.json
+++ b/data/xml2jsObjects/point_simplepoint_nestedLogicalFilters.json
@@ -1,0 +1,89 @@
+{
+  "StyledLayerDescriptor": {
+    "$": {
+      "version": "1.0.0",
+      "xsi:schemaLocation": "http://www.opengis.net/sld StyledLayerDescriptor.xsd",
+      "xmlns": "http://www.opengis.net/sld",
+      "xmlns:ogc": "http://www.opengis.net/ogc",
+      "xmlns:xlink": "http://www.w3.org/1999/xlink",
+      "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance"
+    },
+    "NamedLayer": [{
+      "Name": ["Simple Point Filter"],
+      "UserStyle": [{
+        "Title": ["Simple Point Filter"],
+        "FeatureTypeStyle": [{
+          "Rule": [{
+            "Name": ["Test"],
+            "Filter": [{
+              "$": {
+                "xmlns": "http://www.opengis.net/ogc"
+              },
+              "And": [{
+                "Or": [{
+                  "PropertyIsEqualTo": [{
+                    "PropertyName": ["ID"],
+                    "Literal": [1]
+                  }, {
+                    "PropertyName": ["ID"],
+                    "Literal": [2]
+                  }]
+                },{
+                  "PropertyIsEqualTo": [{
+                    "PropertyName": ["STREET"],
+                    "Literal": ["Main"]
+                  }, {
+                    "PropertyName": ["STREET"],
+                    "Literal": ["Time square"]
+                  }]
+                }, {
+                    "And": [{
+                      "PropertyIsGreaterThanOrEqualTo": [{
+                        "PropertyName": ["HOUSENO"],
+                        "Literal": [1909]
+                      }],
+                      "PropertyIsLessThanOrEqualTo": [{
+                        "PropertyName": ["HOUSENO"],
+                        "Literal": [19909]
+                      }]
+                    }]
+                  }]
+                }]
+              }]
+            }],
+            "MinScaleDenominator": ["10000"],
+            "MaxScaleDenominator": ["20000"],
+            "PointSymbolizer": [{
+              "Graphic": [{
+                "Mark": [{
+                  "WellKnownName": ["circle"],
+                  "Fill": [{
+                    "CssParameter": [{
+                      "_": "#FF0000",
+                      "$": {
+                        "name": "fill"
+                      }
+                    }]
+                  }],
+                  "Stroke": [{
+                    "CssParameter": [{
+                      "_": "#000000",
+                      "$": {
+                        "name": "stroke"
+                      }
+                    }, {
+                      "_": "2",
+                      "$": {
+                        "name": "stroke-width"
+                      }
+                    }]
+                  }]
+                }],
+                "Size": ["6"]
+              }]
+            }]
+          }]
+        }]
+      }]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "build": "tsc -p tsconfig.build.json",
     "pretest": "npm run lint",
     "test": "jest",
+    "test:watch": "jest --watchAll",
     "lint": "tslint --project tsconfig.json --config tslint.json && tsc --noEmit --project tsconfig.build.json",
     "release": "np --no-yarn"
   },

--- a/src/SldStyleParser.spec.ts
+++ b/src/SldStyleParser.spec.ts
@@ -7,6 +7,7 @@ import line_simpleline from '../data/styles/line_simpleline';
 import polygon_transparentpolygon from '../data/styles/polygon_transparentpolygon';
 import point_styledlabel from '../data/styles/point_styledlabel';
 import point_simplepoint_filter from '../data/styles/point_simplepoint_filter';
+import point_simplepoint_nestedLogicalFilters from '../data/styles/point_simplepoint_nestedLogicalFilters';
 import point_externalgraphic from '../data/styles/point_externalgraphic';
 
 it('SldStyleParser is defined', () => {
@@ -89,6 +90,15 @@ describe('SldStyleParser implements StyleParser', () => {
         .then((geoStylerStyle: Style) => {
           expect(geoStylerStyle).toBeDefined();
           expect(geoStylerStyle).toEqual(point_simplepoint_filter);
+        });
+    });
+    it('can read a SLD style with nested logical filters', () => {
+      expect.assertions(2);
+      const sld = fs.readFileSync( './data/slds/point_simplepoint_nestedLogicalFilters.sld', 'utf8');
+      return styleParser.readStyle(sld)
+        .then((geoStylerStyle: Style) => {
+          expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(point_simplepoint_nestedLogicalFilters);
         });
     });
 
@@ -238,6 +248,19 @@ describe('SldStyleParser implements StyleParser', () => {
           return styleParser.readStyle(sldString)
             .then(readStyle => {
               expect(readStyle).toEqual(point_simplepoint_filter);
+            });
+        });
+    });
+    it('can write a SLD style with nested logical filters', () => {
+      expect.assertions(2);
+      return styleParser.writeStyle(point_simplepoint_nestedLogicalFilters)
+        .then((sldString: string) => {
+          expect(sldString).toBeDefined();
+          // As string comparison between to XML-Strings is awkward and nonesens
+          // we read it again and compare the json input with the parser output
+          return styleParser.readStyle(sldString)
+            .then(readStyle => {
+              expect(readStyle).toEqual(point_simplepoint_nestedLogicalFilters);
             });
         });
     });

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -1032,20 +1032,41 @@ class SldStyleParser implements StyleParser {
       // TODO Implement logic for "PropertyIsBetween" filter
       const combinator = sldOperators[0];
       sldFilter[combinator] = [{}];
-      args.forEach((subFilter, idx) => {
+      args.forEach((subFilter, subFilterIdx) => {
         const sldSubFilter = this.getSldFilterFromFilter(subFilter);
         const filterName = Object.keys(sldSubFilter)[0];
+        const isCombinationFilter = (fName: string) => ['And', 'Or'].includes(fName);
+
         if (subFilter[0] === '||' || subFilter[0] === '&&') {
-          sldFilter[combinator][0][filterName] = {};
+          if (isCombinationFilter(filterName)) {
+            if (!(sldFilter[combinator][0][filterName])) {
+              sldFilter[combinator][0][filterName] = [];
+            }
+            sldFilter[combinator][0][filterName][subFilterIdx] = {};
+          } else {
+            sldFilter[combinator][0][filterName] = {};
+          }
+          const parentFilterName = Object.keys(sldSubFilter)[0];
+
           subFilter.forEach((el: any, index: number) => {
             if (index > 0) {
               const sldSubFilter2 = this.getSldFilterFromFilter(el);
               const filterName2 = Object.keys(sldSubFilter2)[0];
-              const parentFilterName = Object.keys(sldSubFilter)[0];
+              if (isCombinationFilter(parentFilterName)) {
+                if (!(sldFilter[combinator][0][parentFilterName][subFilterIdx])) {
+                  sldFilter[combinator][0][parentFilterName][subFilterIdx] = {};
+                }
+                if (!sldFilter[combinator][0][parentFilterName][subFilterIdx][filterName2]) {
+                  sldFilter[combinator][0][parentFilterName][subFilterIdx][filterName2] = [];
+                }
+                sldFilter[combinator][0][parentFilterName][subFilterIdx][filterName2]
+                  .push(sldSubFilter2[filterName2][0]);
+              } else {
               if (!sldFilter[combinator][0][parentFilterName][filterName2]) {
                 sldFilter[combinator][0][parentFilterName][filterName2] = [];
               }
               sldFilter[combinator][0][parentFilterName][filterName2].push(sldSubFilter2[filterName2][0]);
+              }
             }
           });
         } else {
@@ -1059,7 +1080,6 @@ class SldStyleParser implements StyleParser {
     } else if (Object.values(SldStyleParser.negationOperatorMap).includes(operator)) {
       sldFilter.Not = args.map(subFilter => this.getSldFilterFromFilter(subFilter));
     }
-
     return sldFilter;
   }
 

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -1052,21 +1052,14 @@ class SldStyleParser implements StyleParser {
             if (index > 0) {
               const sldSubFilter2 = this.getSldFilterFromFilter(el);
               const filterName2 = Object.keys(sldSubFilter2)[0];
-              if (isCombinationFilter(parentFilterName)) {
-                if (!(sldFilter[combinator][0][parentFilterName][subFilterIdx])) {
-                  sldFilter[combinator][0][parentFilterName][subFilterIdx] = {};
-                }
-                if (!sldFilter[combinator][0][parentFilterName][subFilterIdx][filterName2]) {
-                  sldFilter[combinator][0][parentFilterName][subFilterIdx][filterName2] = [];
-                }
-                sldFilter[combinator][0][parentFilterName][subFilterIdx][filterName2]
-                  .push(sldSubFilter2[filterName2][0]);
-              } else {
-              if (!sldFilter[combinator][0][parentFilterName][filterName2]) {
-                sldFilter[combinator][0][parentFilterName][filterName2] = [];
+              if (!(sldFilter[combinator][0][parentFilterName][subFilterIdx])) {
+                sldFilter[combinator][0][parentFilterName][subFilterIdx] = {};
               }
-              sldFilter[combinator][0][parentFilterName][filterName2].push(sldSubFilter2[filterName2][0]);
+              if (!sldFilter[combinator][0][parentFilterName][subFilterIdx][filterName2]) {
+                sldFilter[combinator][0][parentFilterName][subFilterIdx][filterName2] = [];
               }
+              sldFilter[combinator][0][parentFilterName][subFilterIdx][filterName2]
+                .push(sldSubFilter2[filterName2][0]);
             }
           });
         } else {


### PR DESCRIPTION
This PR fixes `getSldFilterFromFilter` method that currently doesn't support multiple logical filter operations on the same level, e.g.

```
<And>
    <Or>
        <PropertyIsEqualTo>
            <PropertyName>ID</PropertyName>
            <Literal>1</Literal>
        </PropertyIsEqualTo>
        <PropertyIsEqualTo>
            <PropertyName>ID</PropertyName>
            <Literal>2</Literal>
        </PropertyIsEqualTo>
    </Or>
    <Or>
        <PropertyIsEqualTo>
            <PropertyName>STREET</PropertyName>
            <Literal>Main</Literal>
        </PropertyIsEqualTo>
        <PropertyIsEqualTo>
            <PropertyName>STREET</PropertyName>
            <Literal>Time square</Literal>
        </PropertyIsEqualTo>
        <And>
            <PropertyIsGreaterThanOrEqualTo>
                <PropertyName>HOUSENO</PropertyName>
                <Literal>1909</Literal>
            </PropertyIsGreaterThanOrEqualTo>
            <PropertyIsLessThanOrEqualTo>
                <PropertyName>HOUSENO</PropertyName>
                <Literal>19909</Literal>
            </PropertyIsLessThanOrEqualTo>
        </And>
    </Or>
</And>
```

which commonly occur in nested filters.