### PR TITLE
This fixes the name property

### DIFF
--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -40,7 +40,7 @@ class SldStyleParser implements StyleParser {
   /**
    * The name of the SLD Style Parser.
    */
-  public name: 'SLD Style Parser';
+  public name = 'SLD Style Parser';
 
   static negationOperatorMap = {
     Not: '!'


### PR DESCRIPTION
This fixes the wrong semantic/syntax of the name property.

The `=` does assign the value.
The `:` proposes allowed values.