### PR TITLE
Rename 'name' to 'title' and fix assignment

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@types/lodash": "4.14.108",
     "@types/xml2js": "0.4.2",
-    "geostyler-style": "0.5.0",
+    "geostyler-style": "0.6.0",
     "lodash": "4.17.10",
     "xml2js": "0.4.19",
     "xmldom": "0.1.27"

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -40,7 +40,7 @@ class SldStyleParser implements StyleParser {
   /**
    * The name of the SLD Style Parser.
    */
-  public name: 'SLD Style Parser';
+  public static title = 'SLD Style Parser';
 
   static negationOperatorMap = {
     Not: '!'


### PR DESCRIPTION
This changes `name` to static `title` due to changes in GeoStyler-Style v0.6.0.