### PR TITLE
Parse more CSS parameters for FillSymbolizer

### DIFF
--- a/data/slds/polygon_transparentpolygon.sld
+++ b/data/slds/polygon_transparentpolygon.sld
@@ -19,6 +19,7 @@
             <Stroke>
               <CssParameter name="stroke">#FFFFFF</CssParameter>
               <CssParameter name="stroke-width">2</CssParameter>
+              <CssParameter name="stroke-dasharray">1 0</CssParameter>
             </Stroke>
           </PolygonSymbolizer>
         </Rule>

--- a/data/styles/polygon_transparentpolygon.ts
+++ b/data/styles/polygon_transparentpolygon.ts
@@ -9,7 +9,9 @@ const polygonTransparentPolygon: Style = {
       kind: 'Fill',
       color: '#000080',
       opacity: 0.5,
-      outlineColor: '#FFFFFF'
+      outlineColor: '#FFFFFF',
+      outlineWidth: 2,
+      outlineDasharray: [1, 0]
     }
   }]
 };

--- a/data/xml2jsObjects/polygon_transparentpolygon.json
+++ b/data/xml2jsObjects/polygon_transparentpolygon.json
@@ -46,6 +46,12 @@
                     "$": {
                       "name": "stroke-width"
                     }
+                  },
+                  {
+                    "_": "1 0",
+                    "$": {
+                      "name": "stroke-dasharray"
+                    }
                   }
                 ]
               }]

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@types/lodash": "4.14.110",
     "@types/xml2js": "0.4.3",
-    "geostyler-style": "0.6.0",
+    "geostyler-style": "0.7.0",
     "lodash": "4.17.10",
     "xml2js": "0.4.19",
     "xmldom": "0.1.27"

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -419,6 +419,15 @@ class SldStyleParser implements StyleParser {
       } = cssParameter;
       if (name === 'stroke') {
         fillSymbolizer.outlineColor = value;
+      } else if (name === 'stroke-width') {
+        fillSymbolizer.outlineWidth = parseInt(value, 10);
+      } else if (name === 'stroke-dasharray') {
+        const outlineDasharrayStr = value.split(' ');
+        const outlineDasharray: number[] = [];
+        outlineDasharrayStr.forEach((dashStr: string) => {
+          outlineDasharray.push(parseInt(dashStr, 10));
+        });
+        fillSymbolizer.outlineDasharray = outlineDasharray;
       }
     });
     return fillSymbolizer;
@@ -795,7 +804,9 @@ class SldStyleParser implements StyleParser {
    */
   getSldPolygonSymbolizerFromFillSymbolizer(fillSymbolizer: FillSymbolizer): any {
     const strokePropertyMap = {
-      outlineColor: 'stroke'
+      outlineColor: 'stroke',
+      outlineWidth: 'stroke-width',
+      outlineDasharray: 'stroke-dasharray'
     };
     const fillPropertyMap = {
       color: 'fill',
@@ -808,12 +819,31 @@ class SldStyleParser implements StyleParser {
       .filter((property: any) => property !== 'kind')
       .forEach((property: any) => {
         if (Object.keys(strokePropertyMap).includes(property)) {
+
+          let transformedValue: string = '';
+
+          if (property === 'outlineDasharray') {
+            const paramValue: number[] = fillSymbolizer[property];
+            transformedValue = '';
+            paramValue.forEach((dash: number, idx) => {
+              transformedValue += dash;
+              if (idx < paramValue.length - 1) {
+                transformedValue += ' ';
+              }
+            });
+          } else if (property === 'outlineWidth') {
+            transformedValue = fillSymbolizer[property] + '';
+          } else {
+            transformedValue = fillSymbolizer[property];
+          }
+
           strokeCssParameters.push({
-            '_': fillSymbolizer[property],
+            '_': transformedValue,
             '$': {
               'name': strokePropertyMap[property]
             }
           });
+
         } else if (Object.keys(fillPropertyMap).includes(property)) {
           fillCssParameters.push({
             '_': fillSymbolizer[property],


### PR DESCRIPTION
This adds reading and writing capabilities for the CSS parameters `stroke-width` and `stroke-dasharray` in `FillSymbolizers`.