### PR TITLE
Fixes the parsing of the SLD "stroke-dasharray"

### DIFF
--- a/data/slds/line_simpleline.sld
+++ b/data/slds/line_simpleline.sld
@@ -15,6 +15,7 @@
             <Stroke>
               <CssParameter name="stroke">#000000</CssParameter>
               <CssParameter name="stroke-width">3</CssParameter>
+              <CssParameter name="stroke-dasharray">13 37</CssParameter>
             </Stroke>
           </LineSymbolizer>
        	</Rule>

--- a/data/styles/line_simpleline.ts
+++ b/data/styles/line_simpleline.ts
@@ -8,7 +8,8 @@ const lineSimpleLine: Style = {
     symbolizer: {
       kind: 'Line',
       color: '#000000',
-      width: 3
+      width: 3,
+      dasharray: [13, 37]
     }
   }]
 };

--- a/data/xml2jsObjects/line_simpleline.json
+++ b/data/xml2jsObjects/line_simpleline.json
@@ -31,6 +31,12 @@
                     "$": {
                       "name": "stroke-width"
                     }
+                  },
+                  {
+                    "_": "13 37",
+                    "$": {
+                      "name": "stroke-dasharray"
+                    }
                   }
                 ]
               }]

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -365,7 +365,8 @@ class SldStyleParser implements StyleParser {
           lineSymbolizer.cap = value;
           break;
         case 'stroke-dasharray':
-          lineSymbolizer.dasharray = value;
+          const dashStringAsArray = value.split(' ').map((a: string) => parseFloat(a));
+          lineSymbolizer.dasharray = dashStringAsArray;
           break;
         case 'stroke-dashoffset':
           // Currently not supported by GeoStyler Style
@@ -890,8 +891,12 @@ class SldStyleParser implements StyleParser {
     const cssParameters: any[] = Object.keys(lineSymbolizer)
       .filter((property: any) => property !== 'kind' && propertyMap[property])
       .map((property: any) => {
+        let value = lineSymbolizer[property];
+        if (property === 'dasharray') {
+          value = lineSymbolizer.dasharray!.join(' ');
+        }
         return {
-          '_': lineSymbolizer[property],
+          '_': value,
           '$': {
             'name': propertyMap[property]
           }


### PR DESCRIPTION
This fixes the parsing of the 'stroke-dasharray' from an SLD. It's received as a string and has to be split and parsed into a number.