### PR TITLE
Optimize imports of loadsh

### DIFF
--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -22,11 +22,9 @@ import {
   Builder
 } from 'xml2js';
 
-import {
-  isString as _isString,
-  isNumber as _isNumber,
-  get as _get
-} from 'lodash';
+const _isString = require('lodash/isString');
+const _isNumber = require('lodash/isNumber');
+const _get = require('lodash/get');
 
 /**
  * This parser can be used with the GeoStyler.
@@ -682,10 +680,10 @@ class SldStyleParser implements StyleParser {
       }
       if (rule.scaleDenominator) {
         const {min, max} = rule.scaleDenominator;
-        if (_isNumber(min)) {
+        if (min && _isNumber(min)) {
           sldRule.MinScaleDenominator = [min.toString()];
         }
-        if (_isNumber(max)) {
+        if (max && _isNumber(max)) {
           sldRule.MaxScaleDenominator = [max.toString()];
         }
       }


### PR DESCRIPTION
This changes the way of importing lodash methods.
Before, we had

```
import {
  isString as _isString,
  isNumber as _isNumber,
  get as _get
} from 'lodash';
```
Which lead to the following code after compiling with `tsc`:

`var lodash_1 = require("lodash");`

This leads to an include of the complete library when this module is used and build in parent projects.

After changing the code to
```
const _isString = require('lodash/isString');
const _isNumber = require('lodash/isNumber');
const _get = require('lodash/get');
```
We get the follwoing compiled output:
```
var _isString = require('lodash/isString');
var _isNumber = require('lodash/isNumber');
var _get = require('lodash/get');
```

which effectively will reduce the bundle size of parents by a few hundred kilobytes
