### PR TITLE
Include LineSymbolizer changes in parser

### DIFF
--- a/data/slds/line_graphicStroke.sld
+++ b/data/slds/line_graphicStroke.sld
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0"
+    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+    xmlns="http://www.opengis.net/sld"
+    xmlns:ogc="http://www.opengis.net/ogc"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NamedLayer>
+    <Name>Simple Line</Name>
+    <UserStyle>
+      <Title>Simple Line</Title>
+      <FeatureTypeStyle>
+        <Rule>
+          <LineSymbolizer>
+            <Stroke>
+              <GraphicStroke>
+                <Graphic>
+                  <Mark>
+                    <WellKnownName>circle</WellKnownName>
+                    <Fill>
+                      <CssParameter name="fill">#FF0000</CssParameter>
+                    </Fill>
+                  </Mark>
+                  <Size>7</Size>
+                </Graphic>
+              </GraphicStroke>
+              <CssParameter name="stroke">#000000</CssParameter>
+              <CssParameter name="stroke-width">3</CssParameter>
+              <CssParameter name="stroke-dasharray">13 37</CssParameter>
+              <CssParameter name="stroke-linecap">round</CssParameter>
+              <CssParameter name="stroke-linejoin">mitre</CssParameter>
+            </Stroke>
+          </LineSymbolizer>
+       	</Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/data/slds/line_graphicStroke_externalGraphic.sld
+++ b/data/slds/line_graphicStroke_externalGraphic.sld
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0"
+    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+    xmlns="http://www.opengis.net/sld"
+    xmlns:ogc="http://www.opengis.net/ogc"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NamedLayer>
+    <Name>Simple Line</Name>
+    <UserStyle>
+      <Title>Simple Line</Title>
+      <FeatureTypeStyle>
+        <Rule>
+          <LineSymbolizer>
+            <Stroke>
+              <GraphicStroke>
+                <Graphic>
+                  <ExternalGraphic>
+                      <OnlineResource xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://geoserver.org/img/geoserver-logo.png" />
+                      <Format>image/png</Format>
+                  </ExternalGraphic>
+                  <Size>10</Size>
+                  <Rotation>90</Rotation>
+                </Graphic>
+              </GraphicStroke>
+              <CssParameter name="stroke">#000000</CssParameter>
+              <CssParameter name="stroke-width">3</CssParameter>
+              <CssParameter name="stroke-dasharray">13 37</CssParameter>
+              <CssParameter name="stroke-linecap">round</CssParameter>
+              <CssParameter name="stroke-linejoin">mitre</CssParameter>
+            </Stroke>
+          </LineSymbolizer>
+       	</Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/data/slds/line_graphicStroke_externalGraphic.sld
+++ b/data/slds/line_graphicStroke_externalGraphic.sld
@@ -16,8 +16,8 @@
               <GraphicStroke>
                 <Graphic>
                   <ExternalGraphic>
-                      <OnlineResource xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://geoserver.org/img/geoserver-logo.png" />
-                      <Format>image/png</Format>
+                    <OnlineResource xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://geoserver.org/img/geoserver-logo.png" />
+                    <Format>image/png</Format>
                   </ExternalGraphic>
                   <Size>10</Size>
                   <Rotation>90</Rotation>
@@ -30,7 +30,7 @@
               <CssParameter name="stroke-linejoin">mitre</CssParameter>
             </Stroke>
           </LineSymbolizer>
-       	</Rule>
+        </Rule>
       </FeatureTypeStyle>
     </UserStyle>
   </NamedLayer>

--- a/data/slds/line_perpendicularOffset.sld
+++ b/data/slds/line_perpendicularOffset.sld
@@ -19,9 +19,9 @@
               <CssParameter name="stroke-linecap">round</CssParameter>
               <CssParameter name="stroke-linejoin">mitre</CssParameter>
             </Stroke>
-	          <PerpendicularOffset>3</PerpendicularOffset>
+            <PerpendicularOffset>3</PerpendicularOffset>
           </LineSymbolizer>
-       	</Rule>
+        </Rule>
       </FeatureTypeStyle>
     </UserStyle>
   </NamedLayer>

--- a/data/slds/line_perpendicularOffset.sld
+++ b/data/slds/line_perpendicularOffset.sld
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0"
+    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+    xmlns="http://www.opengis.net/sld"
+    xmlns:ogc="http://www.opengis.net/ogc"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NamedLayer>
+    <Name>Simple Line</Name>
+    <UserStyle>
+      <Title>Simple Line</Title>
+      <FeatureTypeStyle>
+        <Rule>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#000000</CssParameter>
+              <CssParameter name="stroke-width">3</CssParameter>
+              <CssParameter name="stroke-dasharray">13 37</CssParameter>
+              <CssParameter name="stroke-linecap">round</CssParameter>
+              <CssParameter name="stroke-linejoin">mitre</CssParameter>
+            </Stroke>
+	          <PerpendicularOffset>3</PerpendicularOffset>
+          </LineSymbolizer>
+       	</Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/data/slds/line_simpleline.sld
+++ b/data/slds/line_simpleline.sld
@@ -16,6 +16,7 @@
               <CssParameter name="stroke">#000000</CssParameter>
               <CssParameter name="stroke-width">3</CssParameter>
               <CssParameter name="stroke-dasharray">13 37</CssParameter>
+              <CssParameter name="stroke-dashoffset">10</CssParameter>
               <CssParameter name="stroke-linecap">round</CssParameter>
               <CssParameter name="stroke-linejoin">mitre</CssParameter>
             </Stroke>

--- a/data/slds/line_simpleline.sld
+++ b/data/slds/line_simpleline.sld
@@ -16,6 +16,8 @@
               <CssParameter name="stroke">#000000</CssParameter>
               <CssParameter name="stroke-width">3</CssParameter>
               <CssParameter name="stroke-dasharray">13 37</CssParameter>
+              <CssParameter name="stroke-linecap">round</CssParameter>
+              <CssParameter name="stroke-linejoin">mitre</CssParameter>
             </Stroke>
           </LineSymbolizer>
        	</Rule>

--- a/data/styles/line_graphicStroke.ts
+++ b/data/styles/line_graphicStroke.ts
@@ -1,0 +1,24 @@
+import { Style } from 'geostyler-style';
+
+const lineSimpleLine: Style = {
+  name: 'Simple Line',
+  type: 'Line',
+  rules: [{
+    name: '',
+    symbolizer: {
+      kind: 'Line',
+      color: '#000000',
+      width: 3,
+      dasharray: [13, 37],
+      cap: 'round',
+      join: 'miter',
+      graphicStroke: {
+        kind: 'Circle',
+        color: '#FF0000',
+        radius: 7
+      }
+    }
+  }]
+};
+
+export default lineSimpleLine;

--- a/data/styles/line_graphicStroke_externalGraphic.ts
+++ b/data/styles/line_graphicStroke_externalGraphic.ts
@@ -1,0 +1,25 @@
+import { Style } from 'geostyler-style';
+
+const lineSimpleLine: Style = {
+  name: 'Simple Line',
+  type: 'Line',
+  rules: [{
+    name: '',
+    symbolizer: {
+      kind: 'Line',
+      color: '#000000',
+      width: 3,
+      dasharray: [13, 37],
+      cap: 'round',
+      join: 'miter',
+      graphicStroke: {
+        kind: 'Icon',
+        image: 'http://geoserver.org/img/geoserver-logo.png',
+        size: 10,
+        rotate: 90
+      }
+    }
+  }]
+};
+
+export default lineSimpleLine;

--- a/data/styles/line_perpendicularOffset.ts
+++ b/data/styles/line_perpendicularOffset.ts
@@ -1,0 +1,20 @@
+import { Style } from 'geostyler-style';
+
+const lineSimpleLine: Style = {
+  name: 'Simple Line',
+  type: 'Line',
+  rules: [{
+    name: '',
+    symbolizer: {
+      kind: 'Line',
+      color: '#000000',
+      width: 3,
+      dasharray: [13, 37],
+      cap: 'round',
+      join: 'miter',
+      perpendicularOffset: 3
+    }
+  }]
+};
+
+export default lineSimpleLine;

--- a/data/styles/line_simpleline.ts
+++ b/data/styles/line_simpleline.ts
@@ -9,7 +9,9 @@ const lineSimpleLine: Style = {
       kind: 'Line',
       color: '#000000',
       width: 3,
-      dasharray: [13, 37]
+      dasharray: [13, 37],
+      cap: 'round',
+      join: 'miter'
     }
   }]
 };

--- a/data/styles/line_simpleline.ts
+++ b/data/styles/line_simpleline.ts
@@ -11,7 +11,8 @@ const lineSimpleLine: Style = {
       width: 3,
       dasharray: [13, 37],
       cap: 'round',
-      join: 'miter'
+      join: 'miter',
+      dashOffset: 10
     }
   }]
 };

--- a/data/xml2jsObjects/line_graphicStroke.json
+++ b/data/xml2jsObjects/line_graphicStroke.json
@@ -1,0 +1,104 @@
+{
+  "StyledLayerDescriptor": {
+    "$": {
+      "version": "1.0.0",
+      "xsi:schemaLocation": "http://www.opengis.net/sld StyledLayerDescriptor.xsd",
+      "xmlns": "http://www.opengis.net/sld",
+      "xmlns:ogc": "http://www.opengis.net/ogc",
+      "xmlns:xlink": "http://www.w3.org/1999/xlink",
+      "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance"
+    },
+    "NamedLayer": [
+      {
+        "Name": [
+          "Simple Line"
+        ],
+        "UserStyle": [
+          {
+            "Title": [
+              "Simple Line"
+            ],
+            "FeatureTypeStyle": [
+              {
+                "Rule": [
+                  {
+                    "LineSymbolizer": [
+                      {
+                        "Stroke": [
+                          {
+                            "GraphicStroke": [
+                              {
+                                "Graphic": [
+                                  {
+                                    "Mark": [
+                                      {
+                                        "WellKnownName": [
+                                          "circle"
+                                        ],
+                                        "Fill": [
+                                          {
+                                            "CssParameter": [
+                                              {
+                                                "_": "#FF0000",
+                                                "$": {
+                                                  "name": "fill"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ],
+                                    "Size": [
+                                      "7"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ],
+                            "CssParameter": [
+                              {
+                                "_": "#000000",
+                                "$": {
+                                  "name": "stroke"
+                                }
+                              },
+                              {
+                                "_": "3",
+                                "$": {
+                                  "name": "stroke-width"
+                                }
+                              },
+                              {
+                                "_": "13 37",
+                                "$": {
+                                  "name": "stroke-dasharray"
+                                }
+                              },
+                              {
+                                "_": "round",
+                                "$": {
+                                  "name": "stroke-linecap"
+                                }
+                              },
+                              {
+                                "_": "mitre",
+                                "$": {
+                                  "name": "stroke-linejoin"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/data/xml2jsObjects/line_graphicStroke_externalGraphic.json
+++ b/data/xml2jsObjects/line_graphicStroke_externalGraphic.json
@@ -1,0 +1,104 @@
+{
+  "StyledLayerDescriptor": {
+    "$": {
+      "version": "1.0.0",
+      "xsi:schemaLocation": "http://www.opengis.net/sld StyledLayerDescriptor.xsd",
+      "xmlns": "http://www.opengis.net/sld",
+      "xmlns:ogc": "http://www.opengis.net/ogc",
+      "xmlns:xlink": "http://www.w3.org/1999/xlink",
+      "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance"
+    },
+    "NamedLayer": [
+      {
+        "Name": [
+          "Simple Line"
+        ],
+        "UserStyle": [
+          {
+            "Title": [
+              "Simple Line"
+            ],
+            "FeatureTypeStyle": [
+              {
+                "Rule": [
+                  {
+                    "LineSymbolizer": [
+                      {
+                        "Stroke": [
+                          {
+                            "GraphicStroke": [
+                              {
+                                "Graphic": [
+                                  {
+                                    "ExternalGraphic": [
+                                      {
+                                        "OnlineResource": [
+                                          {
+                                            "$": {
+                                              "xlink:type": "simple",
+                                              "xmlns:xlink": "http://www.w3.org/1999/xlink",
+                                              "xlink:href": "http://geoserver.org/img/geoserver-logo.png"
+                                            }
+                                          }
+                                        ],
+                                        "Format": [
+                                          "image/png"
+                                        ]
+                                      }
+                                    ],
+                                    "Size": [
+                                      "10"
+                                    ],
+                                    "Rotation": [
+                                      "90"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ],
+                            "CssParameter": [
+                              {
+                                "_": "#000000",
+                                "$": {
+                                  "name": "stroke"
+                                }
+                              },
+                              {
+                                "_": "3",
+                                "$": {
+                                  "name": "stroke-width"
+                                }
+                              },
+                              {
+                                "_": "13 37",
+                                "$": {
+                                  "name": "stroke-dasharray"
+                                }
+                              },
+                              {
+                                "_": "round",
+                                "$": {
+                                  "name": "stroke-linecap"
+                                }
+                              },
+                              {
+                                "_": "mitre",
+                                "$": {
+                                  "name": "stroke-linejoin"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/data/xml2jsObjects/line_perpendicularOffset.json
+++ b/data/xml2jsObjects/line_perpendicularOffset.json
@@ -1,0 +1,77 @@
+{
+  "StyledLayerDescriptor": {
+    "$": {
+      "version": "1.0.0",
+      "xsi:schemaLocation": "http://www.opengis.net/sld StyledLayerDescriptor.xsd",
+      "xmlns": "http://www.opengis.net/sld",
+      "xmlns:ogc": "http://www.opengis.net/ogc",
+      "xmlns:xlink": "http://www.w3.org/1999/xlink",
+      "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance"
+    },
+    "NamedLayer": [
+      {
+        "Name": [
+          "Simple Line"
+        ],
+        "UserStyle": [
+          {
+            "Title": [
+              "Simple Line"
+            ],
+            "FeatureTypeStyle": [
+              {
+                "Rule": [
+                  {
+                    "LineSymbolizer": [
+                      {
+                        "Stroke": [
+                          {
+                            "CssParameter": [
+                              {
+                                "_": "#000000",
+                                "$": {
+                                  "name": "stroke"
+                                }
+                              },
+                              {
+                                "_": "3",
+                                "$": {
+                                  "name": "stroke-width"
+                                }
+                              },
+                              {
+                                "_": "13 37",
+                                "$": {
+                                  "name": "stroke-dasharray"
+                                }
+                              },
+                              {
+                                "_": "round",
+                                "$": {
+                                  "name": "stroke-linecap"
+                                }
+                              },
+                              {
+                                "_": "mitre",
+                                "$": {
+                                  "name": "stroke-linejoin"
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "PerpendicularOffset": [
+                          "3"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/data/xml2jsObjects/line_simpleline.json
+++ b/data/xml2jsObjects/line_simpleline.json
@@ -37,6 +37,18 @@
                     "$": {
                       "name": "stroke-dasharray"
                     }
+                  },
+                  {
+                    "_": "round",
+                    "$": {
+                      "name": "stroke-linecap"
+                    }
+                  },
+                  {
+                    "_": "mitre",
+                    "$": {
+                      "name": "stroke-linejoin"
+                    }
                   }
                 ]
               }]

--- a/data/xml2jsObjects/line_simpleline.json
+++ b/data/xml2jsObjects/line_simpleline.json
@@ -49,6 +49,12 @@
                     "$": {
                       "name": "stroke-linejoin"
                     }
+                  },
+                  {
+                    "_": "10",
+                    "$": {
+                      "name": "stroke-dashoffset"
+                    }
                   }
                 ]
               }]

--- a/package.json
+++ b/package.json
@@ -45,14 +45,13 @@
     "@types/jest": "23.3.1",
     "@types/node": "10.5.7",
     "coveralls": "3.0.1",
-    "jest": "23.4.2",
+    "jest": "23.1.0",
     "np": "3.0.4",
     "ts-jest": "23.0.1",
     "tslint": "5.10.0",
     "typescript": "2.9.1"
   },
   "jest": {
-    "testURL": "http://localhost/",
     "moduleFileExtensions": [
       "ts",
       "js"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@types/lodash": "4.14.116",
     "@types/xml2js": "0.4.3",
-    "geostyler-style": "0.7.0",
+    "geostyler-style": "0.8.0",
     "lodash": "4.17.10",
     "xml2js": "0.4.19",
     "xmldom": "0.1.27"

--- a/package.json
+++ b/package.json
@@ -45,13 +45,14 @@
     "@types/jest": "23.3.1",
     "@types/node": "10.5.7",
     "coveralls": "3.0.1",
-    "jest": "23.1.0",
+    "jest": "23.4.2",
     "np": "3.0.4",
     "ts-jest": "23.0.1",
     "tslint": "5.10.0",
     "typescript": "2.9.1"
   },
   "jest": {
+    "testURL": "http://localhost/",
     "moduleFileExtensions": [
       "ts",
       "js"

--- a/src/SldStyleParser.spec.ts
+++ b/src/SldStyleParser.spec.ts
@@ -4,6 +4,7 @@ import { Style } from 'geostyler-style';
 
 import point_simplepoint from '../data/styles/point_simplepoint';
 import line_simpleline from '../data/styles/line_simpleline';
+import line_perpendicularOffset from '../data/styles/line_perpendicularOffset';
 import polygon_transparentpolygon from '../data/styles/polygon_transparentpolygon';
 import point_styledlabel from '../data/styles/point_styledlabel';
 import point_simplepoint_filter from '../data/styles/point_simplepoint_filter';
@@ -63,6 +64,15 @@ describe('SldStyleParser implements StyleParser', () => {
       .then((geoStylerStyle: Style) => {
         expect(geoStylerStyle).toBeDefined();
         expect(geoStylerStyle).toEqual(line_simpleline);
+      });
+    });
+    it('can read a SLD LineSymbolizer with Perpendicular Offset', () => {
+      expect.assertions(2);
+      const sld = fs.readFileSync( './data/slds/line_perpendicularOffset.sld', 'utf8');
+      return styleParser.readStyle(sld)
+      .then((geostylerStyle: Style) => {
+        expect(geostylerStyle).toBeDefined();
+        expect(geostylerStyle).toEqual(line_perpendicularOffset);
       });
     });
     it('can read a SLD PolygonSymbolizer', () => {
@@ -209,6 +219,19 @@ describe('SldStyleParser implements StyleParser', () => {
           return styleParser.readStyle(sldString)
             .then(readStyle => {
               expect(readStyle).toEqual(line_simpleline);
+            });
+        });
+    });
+    it('can write a SLD LineSymbolizer with PerpendicularOffset', () => {
+      expect.assertions(2);
+      return styleParser.writeStyle(line_perpendicularOffset)
+        .then((sldString: string) => {
+          expect(sldString).toBeDefined();
+          // As string comparison between to XML-Strings is awkward and nonesens
+          // we read it again and compare the json input with the parser output
+          return styleParser.readStyle(sldString)
+            .then(readStyle => {
+              expect(readStyle).toEqual(line_perpendicularOffset);
             });
         });
     });

--- a/src/SldStyleParser.spec.ts
+++ b/src/SldStyleParser.spec.ts
@@ -5,6 +5,8 @@ import { Style } from 'geostyler-style';
 import point_simplepoint from '../data/styles/point_simplepoint';
 import line_simpleline from '../data/styles/line_simpleline';
 import line_perpendicularOffset from '../data/styles/line_perpendicularOffset';
+import line_graphicStroke from '../data/styles/line_graphicStroke';
+import line_graphicStroke_externalGraphic from '../data/styles/line_graphicStroke_externalGraphic';
 import polygon_transparentpolygon from '../data/styles/polygon_transparentpolygon';
 import point_styledlabel from '../data/styles/point_styledlabel';
 import point_simplepoint_filter from '../data/styles/point_simplepoint_filter';
@@ -74,6 +76,24 @@ describe('SldStyleParser implements StyleParser', () => {
         expect(geostylerStyle).toBeDefined();
         expect(geostylerStyle).toEqual(line_perpendicularOffset);
       });
+    });
+    it('can read a SLD LineSymbolizer with GraphicStroke', () => {
+      expect.assertions(2);
+      const sld = fs.readFileSync( './data/slds/line_graphicStroke.sld', 'utf8');
+      return styleParser.readStyle(sld)
+        .then((geoStylerStyle: Style) => {
+          expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(line_graphicStroke);
+        });
+    });
+    it('can read a SLD LineSymbolizer with GraphicStroke and ExternalGraphic', () => {
+      expect.assertions(2);
+      const sld = fs.readFileSync( './data/slds/line_graphicStroke_externalGraphic.sld', 'utf8');
+      return styleParser.readStyle(sld)
+        .then((geoStylerStyle: Style) => {
+          expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(line_graphicStroke_externalGraphic);
+        });
     });
     it('can read a SLD PolygonSymbolizer', () => {
       expect.assertions(2);
@@ -232,6 +252,32 @@ describe('SldStyleParser implements StyleParser', () => {
           return styleParser.readStyle(sldString)
             .then(readStyle => {
               expect(readStyle).toEqual(line_perpendicularOffset);
+            });
+        });
+    });
+    it('can write a SLD LineSymbolizer with GraphicStroke', () => {
+      expect.assertions(2);
+      return styleParser.writeStyle(line_graphicStroke)
+        .then((sldString: string) => {
+          expect(sldString).toBeDefined();
+          // As string comparison between to XML-Strings is awkward and nonesens
+          // we read it again and compare the json input with the parser output
+          return styleParser.readStyle(sldString)
+            .then(readStyle => {
+              expect(readStyle).toEqual(line_graphicStroke);
+            });
+        });
+    });
+    it('can write a SLD LineSymbolizer with GraphicStroke and ExternalGraphic', () => {
+      expect.assertions(2);
+      return styleParser.writeStyle(line_graphicStroke_externalGraphic)
+        .then((sldString: string) => {
+          expect(sldString).toBeDefined();
+          // As string comparison between to XML-Strings is awkward and nonesens
+          // we read it again and compare the json input with the parser output
+          return styleParser.readStyle(sldString)
+            .then(readStyle => {
+              expect(readStyle).toEqual(line_graphicStroke_externalGraphic);
             });
         });
     });

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -338,7 +338,7 @@ class SldStyleParser implements StyleParser {
     if (strokeKeys.length < 1) {
       throw new Error(`LineSymbolizer cannot be parsed. No Stroke detected`);
     }
-    strokeKeys.forEach((strokeKey: any) => {
+    strokeKeys.forEach((strokeKey: string) => {
       switch (strokeKey) {
         case 'CssParameter':
           const cssParameters = _get(sldSymbolizer, 'Stroke[0].CssParameter') || [];

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -372,7 +372,7 @@ class SldStyleParser implements StyleParser {
           lineSymbolizer.dasharray = dashStringAsArray;
           break;
         case 'stroke-dashoffset':
-          // Currently not supported by GeoStyler Style
+          lineSymbolizer.dashOffset = parseFloat(value);
           break;
         default:
           break;
@@ -892,7 +892,8 @@ class SldStyleParser implements StyleParser {
       opacity: 'stroke-opacity',
       join: 'stroke-linejoin',
       cap: 'stroke-linecap',
-      dasharray: 'stroke-dasharray'
+      dasharray: 'stroke-dasharray',
+      dashOffset: 'stroke-dashoffset'
     };
 
     const cssParameters: any[] = Object.keys(lineSymbolizer)

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -387,7 +387,9 @@ class SldStyleParser implements StyleParser {
           });
           break;
         case 'GraphicStroke':
-          lineSymbolizer.graphicStroke = this.getPointSymbolizerFromSldSymbolizer(_get(sldSymbolizer, 'Stroke[0].GraphicStroke[0]'));
+          lineSymbolizer.graphicStroke = this.getPointSymbolizerFromSldSymbolizer(
+            _get(sldSymbolizer, 'Stroke[0].GraphicStroke[0]')
+          );
           break;
         default:
           break;
@@ -911,10 +913,9 @@ class SldStyleParser implements StyleParser {
       dashOffset: 'stroke-dashoffset'
     };
 
-    let result:any = {
+    let result: any = {
       'LineSymbolizer': [{
-        'Stroke': [{
-        }]
+        'Stroke': [{}]
       }]
     };
 
@@ -939,7 +940,7 @@ class SldStyleParser implements StyleParser {
 
     const perpendicularOffset = lineSymbolizer.perpendicularOffset;
 
-    if (cssParameters.length != 0) {
+    if (cssParameters.length !== 0) {
       result.LineSymbolizer[0].Stroke[0].CssParameter = cssParameters;
     }
     if (perpendicularOffset) {
@@ -947,12 +948,14 @@ class SldStyleParser implements StyleParser {
     }
 
     if (_get(lineSymbolizer, 'graphicStroke.kind') === 'Circle') {
-      const graphicStroke = this.getSldPointSymbolizerFromCircleSymbolizer(<CircleSymbolizer>lineSymbolizer.graphicStroke);
+      const graphicStroke = this.getSldPointSymbolizerFromCircleSymbolizer(
+        <CircleSymbolizer> lineSymbolizer.graphicStroke
+      );
       result.LineSymbolizer[0].Stroke[0].GraphicStroke = [graphicStroke.PointSymbolizer[0]];
     }
 
     if (_get(lineSymbolizer, 'graphicStroke.kind') === 'Icon') {
-      const graphicStroke = this.getSldPointSymbolizerFromIconSymbolizer(<IconSymbolizer>lineSymbolizer.graphicStroke);
+      const graphicStroke = this.getSldPointSymbolizerFromIconSymbolizer(<IconSymbolizer> lineSymbolizer.graphicStroke);
       result.LineSymbolizer[0].Stroke[0].GraphicStroke = [graphicStroke.PointSymbolizer[0]];
     }
 

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -357,7 +357,12 @@ class SldStyleParser implements StyleParser {
           lineSymbolizer.opacity = parseFloat(value);
           break;
         case 'stroke-linejoin':
-          lineSymbolizer.join = value;
+          // geostyler-style and ol use 'miter' whereas sld uses 'mitre'
+          if (value === 'mitre') {
+            lineSymbolizer.join = 'miter';
+          } else {
+            lineSymbolizer.join = value;
+          }
           break;
         case 'stroke-linecap':
           lineSymbolizer.cap = value;
@@ -892,6 +897,10 @@ class SldStyleParser implements StyleParser {
         let value = lineSymbolizer[property];
         if (property === 'dasharray') {
           value = lineSymbolizer.dasharray!.join(' ');
+        }
+        // simple transformation since geostyler-style uses prop 'miter' whereas sld uses 'mitre'
+        if (property === 'join' && value === 'miter') {
+          value = 'mitre';
         }
         return {
           '_': value,

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -378,6 +378,10 @@ class SldStyleParser implements StyleParser {
           break;
       }
     });
+    const perpendicularOffset = _get(sldSymbolizer, 'PerpendicularOffset[0]');
+    if (perpendicularOffset !== undefined) {
+      lineSymbolizer.perpendicularOffset = Number(perpendicularOffset);
+    }
     return lineSymbolizer;
   }
 
@@ -910,13 +914,21 @@ class SldStyleParser implements StyleParser {
         };
       });
 
-    return {
+    const perpendicularOffset = lineSymbolizer.perpendicularOffset;
+    let result = {
       'LineSymbolizer': [{
         'Stroke': [{
           'CssParameter': cssParameters
-        }]
+        }],
+        'PerpendicularOffset': [perpendicularOffset]
       }]
     };
+    
+    if (_get(result, 'LineSymbolizer[0].PerpendicularOffset[0]') === undefined) {
+      delete result.LineSymbolizer[0].PerpendicularOffset;
+    }
+
+    return result;
   }
 
   /**


### PR DESCRIPTION
**Important:** Please wait with merging this PR until 
- [x] [this PR of geostyler-style](https://github.com/terrestris/geostyler-style/pull/38) 
was merged.

`stroke-linecap`, `stroke-linejoin`, `perpendicularOffset`, `stroke-dashoffset`, `graphic-stroke`, will now be parsed. Tests and tesfiles were updated accordingly.