### PR TITLE
Parse Format of ExternalGraphic

### DIFF
--- a/data/slds/point_externalgraphic_svg.sld
+++ b/data/slds/point_externalgraphic_svg.sld
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0"
+    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+    xmlns="http://www.opengis.net/sld"
+    xmlns:ogc="http://www.opengis.net/ogc"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NamedLayer>
+    <Name>External Graphic</Name>
+    <UserStyle>
+      <Title>External Graphic</Title>
+      <FeatureTypeStyle>
+        <Rule>
+          <PointSymbolizer>
+              <Graphic>
+                  <ExternalGraphic>
+                      <OnlineResource xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://upload.wikimedia.org/wikipedia/commons/6/67/OpenLayers_logo.svg" />
+                      <Format>image/svg+xml</Format>
+                  </ExternalGraphic>
+                  <Size>10</Size>
+                  <Rotation>90</Rotation>
+              </Graphic>
+          </PointSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/data/styles/point_externalgraphic_svg.ts
+++ b/data/styles/point_externalgraphic_svg.ts
@@ -1,0 +1,16 @@
+import { Style } from 'geostyler-style';
+
+const pointExternalGraphic: Style = {
+  name: 'External Graphic',
+  rules: [{
+    name: '',
+    symbolizers: [{
+      kind: 'Icon',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/6/67/OpenLayers_logo.svg',
+      size: 10,
+      rotate: 90
+    }]
+  }]
+};
+
+export default pointExternalGraphic;

--- a/data/xml2jsObjects/point_externalgraphic_svg.json
+++ b/data/xml2jsObjects/point_externalgraphic_svg.json
@@ -25,11 +25,11 @@
                     "$": {
                       "xlink:type": "simple",
                       "xmlns:xlink": "http://www.w3.org/1999/xlink",
-                      "xlink:href": "http://geoserver.org/img/geoserver-logo.png"
+                      "xlink:href": "https://upload.wikimedia.org/wikipedia/commons/6/67/OpenLayers_logo.svg"
                     }
                   }],
                   "Format": [
-                    "image/png"
+                    "image/svg+xml"
                   ]
                 }],
                 "Size": [

--- a/src/SldStyleParser.spec.ts
+++ b/src/SldStyleParser.spec.ts
@@ -16,6 +16,7 @@ import point_styledlabel from '../data/styles/point_styledlabel';
 import point_simplepoint_filter from '../data/styles/point_simplepoint_filter';
 import point_simplepoint_nestedLogicalFilters from '../data/styles/point_simplepoint_nestedLogicalFilters';
 import point_externalgraphic from '../data/styles/point_externalgraphic';
+import point_externalgraphic_svg from '../data/styles/point_externalgraphic_svg';
 import multi_simplelineLabel from '../data/styles/multi_simplelineLabel';
 import point_simplesquare from '../data/styles/point_simplesquare';
 import point_simpletriangle from '../data/styles/point_simpletriangle';
@@ -69,6 +70,15 @@ describe('SldStyleParser implements StyleParser', () => {
           expect(geoStylerStyle).toEqual(point_externalgraphic);
         });
       });
+    it('can read a SLD PointSymbolizer with ExternalGraphic svg', () => {
+      expect.assertions(2);
+      const sld = fs.readFileSync( './data/slds/point_externalgraphic_svg.sld', 'utf8');
+      return styleParser.readStyle(sld)
+        .then((geoStylerStyle: Style) => {
+          expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(point_externalgraphic_svg);
+        });
+    });
     it('can read a SLD PointSymbolizer with wellKnownName square', () => {
       expect.assertions(2);
       const sld = fs.readFileSync( './data/slds/point_simplesquare.sld', 'utf8');
@@ -320,6 +330,19 @@ describe('SldStyleParser implements StyleParser', () => {
           return styleParser.readStyle(sldString)
             .then(readStyle => {
               expect(readStyle).toEqual(point_externalgraphic);
+            });
+        });
+    });
+    it('can write a SLD PointSymbolizer with ExternalGraphic svg', () => {
+      expect.assertions(2);
+      return styleParser.writeStyle(point_externalgraphic_svg)
+        .then((sldString: string) => {
+          expect(sldString).toBeDefined();
+          // As string comparison between to XML-Strings is awkward and nonesens
+          // we read it again and compare the json input with the parser output
+          return styleParser.readStyle(sldString)
+            .then(readStyle => {
+              expect(readStyle).toEqual(point_externalgraphic_svg);
             });
         });
     });

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -1285,6 +1285,9 @@ class SldStyleParser implements StyleParser {
         case 'gif':
           graphic[0].ExternalGraphic[0].Format = [`image/${iconExt}`];
           break;
+        case 'jpg':
+          graphic[0].ExternalGraphic[0].Format = ['image/jpeg'];
+          break;
         case 'svg':
           graphic[0].ExternalGraphic[0].Format = ['image/svg+xml'];
           break;


### PR DESCRIPTION
With this PR, `Format` tag of SLDs `ExternalGraphic` will be parsed. geostyler-style and all other parsers and Components remain the same. Also, create new `getIconSymbolizerFromSldSymbolizer()` to keep code easier to read.

Supported mime-types are:
`image/png` `image/jpeg` `image/gif` `image/svg+xml`