### PR TITLE
Parse TextSymbolizer templates

### DIFF
--- a/data/slds/point_styledLabel_literalPlaceholder.sld
+++ b/data/slds/point_styledLabel_literalPlaceholder.sld
@@ -9,7 +9,7 @@
           <TextSymbolizer>
             <Label>
               <ogc:PropertyName>name</ogc:PropertyName>
-              <Literal><![CDATA[ ]]>entity</Literal>
+              <ogc:Literal> entity</ogc:Literal>
             </Label>
             <Font>
               <CssParameter name="font-family">Arial</CssParameter>

--- a/data/slds/point_styledLabel_literalPlaceholder.sld
+++ b/data/slds/point_styledLabel_literalPlaceholder.sld
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NamedLayer>
+    <Name>Styled Label</Name>
+    <UserStyle>
+      <Title>Styled Label</Title>
+      <FeatureTypeStyle>
+        <Rule>
+          <TextSymbolizer>
+            <Label>
+              <ogc:PropertyName>name</ogc:PropertyName>
+              <Literal><![CDATA[ ]]>entity</Literal>
+            </Label>
+            <Font>
+              <CssParameter name="font-family">Arial</CssParameter>
+              <CssParameter name="font-size">12</CssParameter>
+              <CssParameter name="font-style">normal</CssParameter>
+              <CssParameter name="font-weight">bold</CssParameter>
+            </Font>
+            <LabelPlacement>
+              <PointPlacement>
+                <AnchorPoint>
+                  <AnchorPointX>0.5</AnchorPointX>
+                  <AnchorPointY>0.0</AnchorPointY>
+                </AnchorPoint>
+                <Displacement>
+                  <DisplacementX>0</DisplacementX>
+                  <DisplacementY>5</DisplacementY>
+                </Displacement>
+                <Rotation>45</Rotation>
+              </PointPlacement>
+            </LabelPlacement>
+            <Halo>
+              <Radius>5</Radius>
+              <Fill>
+                <CssParameter name="fill">#000000</CssParameter>
+                <CssParameter name="fill-opacity">1</CssParameter>
+              </Fill>
+            </Halo>
+            <Fill>
+              <CssParameter name="fill">#000000</CssParameter>
+            </Fill>
+          </TextSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/data/styles/multi_simplelineLabel.ts
+++ b/data/styles/multi_simplelineLabel.ts
@@ -12,7 +12,7 @@ const multiSimplelineLabel: Style = {
     }, {
       kind: 'Text',
       color: '#000000',
-      field: 'name',
+      label: '{{name}}',
       font: ['Arial'],
       size: 12,
       offset: [0, 5]

--- a/data/styles/point_styledLabel_literalPlaceholder.ts
+++ b/data/styles/point_styledLabel_literalPlaceholder.ts
@@ -7,7 +7,7 @@ const pointStyledLabel: Style = {
     symbolizers: [{
       kind: 'Text',
       color: '#000000',
-      label: '{{name}}',
+      label: '{{name}} entity',
       font: ['Arial'],
       size: 12,
       offset: [0, 5],

--- a/data/xml2jsObjects/point_styledLabel_literalPlaceholder.json
+++ b/data/xml2jsObjects/point_styledLabel_literalPlaceholder.json
@@ -1,0 +1,146 @@
+{
+  "StyledLayerDescriptor": {
+    "$": {
+      "version": "1.0.0",
+      "xsi:schemaLocation": "http://www.opengis.net/sld StyledLayerDescriptor.xsd",
+      "xmlns": "http://www.opengis.net/sld",
+      "xmlns:ogc": "http://www.opengis.net/ogc",
+      "xmlns:xlink": "http://www.w3.org/1999/xlink",
+      "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance"
+    },
+    "NamedLayer": [
+      {
+        "Name": [
+          "Styled Label"
+        ],
+        "UserStyle": [
+          {
+            "Title": [
+              "Styled Label"
+            ],
+            "FeatureTypeStyle": [
+              {
+                "Rule": [
+                  {
+                    "TextSymbolizer": [
+                      {
+                        "Label": [
+                          {
+                            "ogc:PropertyName": [
+                              "name"
+                            ],
+                            "Literal": [
+                              " entity"
+                            ]
+                          }
+                        ],
+                        "Font": [
+                          {
+                            "CssParameter": [
+                              {
+                                "_": "Arial",
+                                "$": {
+                                  "name": "font-family"
+                                }
+                              },
+                              {
+                                "_": "12",
+                                "$": {
+                                  "name": "font-size"
+                                }
+                              },
+                              {
+                                "_": "normal",
+                                "$": {
+                                  "name": "font-style"
+                                }
+                              },
+                              {
+                                "_": "bold",
+                                "$": {
+                                  "name": "font-weight"
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "LabelPlacement": [
+                          {
+                            "PointPlacement": [
+                              {
+                                "AnchorPoint": [
+                                  {
+                                    "AnchorPointX": [
+                                      "0.5"
+                                    ],
+                                    "AnchorPointY": [
+                                      "0.0"
+                                    ]
+                                  }
+                                ],
+                                "Displacement": [
+                                  {
+                                    "DisplacementX": [
+                                      "0"
+                                    ],
+                                    "DisplacementY": [
+                                      "5"
+                                    ]
+                                  }
+                                ],
+                                "Rotation": [
+                                  "45"
+                                ]
+                              }
+                            ]
+                          }
+                        ],
+                        "Halo": [
+                          {
+                            "Radius": [
+                              "5"
+                            ],
+                            "Fill": [
+                              {
+                                "CssParameter": [
+                                  {
+                                    "_": "#000000",
+                                    "$": {
+                                      "name": "fill"
+                                    }
+                                  },
+                                  {
+                                    "_": "1",
+                                    "$": {
+                                      "name": "fill-opacity"
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ],
+                        "Fill": [
+                          {
+                            "CssParameter": [
+                              {
+                                "_": "#000000",
+                                "$": {
+                                  "name": "fill"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@types/lodash": "4.14.116",
     "@types/xml2js": "0.4.3",
-    "geostyler-style": "0.13.0",
+    "geostyler-style": "0.14.0",
     "lodash": "4.17.11",
     "xml2js": "0.4.19",
     "xmldom": "0.1.27"

--- a/src/SldStyleParser.spec.ts
+++ b/src/SldStyleParser.spec.ts
@@ -24,6 +24,7 @@ import point_simplestar from '../data/styles/point_simplestar';
 import point_simplecross from '../data/styles/point_simplecross';
 import point_simplex from '../data/styles/point_simplex';
 import point_simpleslash from '../data/styles/point_simpleslash';
+import point_styledLabel_literalPlaceholder from '../data/styles/point_styledLabel_literalPlaceholder';
 
 it('SldStyleParser is defined', () => {
   expect(SldStyleParser).toBeDefined();
@@ -251,6 +252,15 @@ describe('SldStyleParser implements StyleParser', () => {
           expect(geoStylerStyle).toEqual(multi_simplelineLabel);
         });
     });
+    it('can read a SLD style with a styled label containing a PropertyName and a Literal', () => {
+      expect.assertions(2);
+      const sld = fs.readFileSync( './data/slds/point_styledLabel_literalPlaceholder.sld', 'utf8');
+      return styleParser.readStyle(sld)
+        .then((geoStylerStyle: Style) => {
+          expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(point_styledLabel_literalPlaceholder);
+        });
+    });
 
     describe('#getFilterFromOperatorAndComparison', () => {
       it('is defined', () => {
@@ -309,6 +319,12 @@ describe('SldStyleParser implements StyleParser', () => {
     describe('#sldObjectToGeoStylerStyle', () => {
       it('is defined', () => {
         expect(styleParser.sldObjectToGeoStylerStyle).toBeDefined();
+      });
+    });
+
+    describe('#getTextSymbolizerLabelFromSldSymbolizer', () => {
+      it('is defined', () => {
+        expect(styleParser.getTextSymbolizerLabelFromSldSymbolizer).toBeDefined();
       });
     });
   });
@@ -603,6 +619,19 @@ describe('SldStyleParser implements StyleParser', () => {
             });
         });
     });
+    it('can write a SLD style with a styled label containing a placeholder and static text', () => {
+      expect.assertions(2);
+      return styleParser.writeStyle(point_styledLabel_literalPlaceholder)
+        .then((sldString: string) => {
+          expect(sldString).toBeDefined();
+          // As string comparison between to XML-Strings is awkward and nonesens
+          // we read it again and compare the json input with the parser output
+          return styleParser.readStyle(sldString)
+            .then(readStyle => {
+              expect(readStyle).toEqual(point_styledLabel_literalPlaceholder);
+            });
+        });
+    });
 
     describe('#geoStylerStyleToSldObject', () => {
       it('is defined', () => {
@@ -655,6 +684,12 @@ describe('SldStyleParser implements StyleParser', () => {
     describe('#getSldFilterFromFilter', () => {
       it('is defined', () => {
         expect(styleParser.getSldFilterFromFilter).toBeDefined();
+      });
+    });
+
+    describe('#getSldLabelFromTextSymbolizer', () => {
+      it('is defined', () => {
+        expect(styleParser.getSldLabelFromTextSymbolizer).toBeDefined();
       });
     });
   });

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -991,14 +991,21 @@ class SldStyleParser implements StyleParser {
     if (!regExpRes) {
       return [
         {
-          'Literal': [template]
+          'ogc:Literal': [template]
         }
       ];
       // if templates are being used
     } else {
       // split the original string at occurences of placeholders
       // the resulting array will be used for the Literal property
-      const literals = template.split(regExp);
+      const literalsWEmptyStrings = template.split(regExp);
+      const literals: string[] = [];
+      // remove empty strings
+      literalsWEmptyStrings.forEach((lit: string) => {
+        if (lit.length !== 0) {
+          literals.push(lit);
+        }
+      });
       // slice the curly braces of the placeholder matches
       // and use the resulting array for the PropertyName property
       const propertyName = regExpRes.map(reg => {
@@ -1009,13 +1016,13 @@ class SldStyleParser implements StyleParser {
       // otherwise Literal must be set first.
       if (startsWithPlaceholder) {
         return [{
-          'PropertyName': propertyName,
-          'Literal': literals
+          'ogc:PropertyName': propertyName,
+          'ogc:Literal': literals
         }];
       } else {
         return [{
-          'Literal': literals,
-          'PropertyName': propertyName
+          'ogc:Literal': literals,
+          'ogc:PropertyName': propertyName
         }];
       }
     }


### PR DESCRIPTION
**Important:** Please wait with merging this PR until
- [x] [this PR from geostyler-style](https://github.com/terrestris/geostyler-style/pull/59)
was merged.

With this PR it is possible to parse templates for TextSymbolizers. Simple text will be parsed as static text. Text in double curly braces (`{{}}`) will be interpreted as feature property. Combinations are possible.

Examples:
```
hello world
--> every feature will display the text 'hello world'
```

```
hello {{world}}
--> every feature will display the text 'hello ',
    appended by the value of its property "world"
```

More examples can be found in the comments.