### PR TITLE
Downgrade webpack to version 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "ts-jest": "23.0.1",
     "tslint": "5.10.0",
     "typescript": "2.9.1",
-    "webpack": "4.23.1",
+    "webpack": "3.12.0",
     "webpack-cli": "3.1.2"
   },
   "jest": {


### PR DESCRIPTION
This downgrades webpack back to version 3 as our `browser-build-config.js` relies on that.