### PR TITLE
Adds greenkeeper-ignore to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,5 +70,11 @@
     "collectCoverageFrom": [
       "src/*.{ts,js}"
     ]
+  },
+  "greenkeeper": {
+    "ignore": [
+      "webpack",
+      "webpack-cli"
+    ]
   }
 }


### PR DESCRIPTION
Ass we don't want to update webpack to v4 this adds a greenkeeper (ignore) section to the package.json.