### PR TITLE
Move dependencies to where they belong

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,6 @@
   },
   "homepage": "https://github.com/terrestris/geostyler-sld-parser#readme",
   "dependencies": {
-    "@types/lodash": "4.14.118",
-    "@types/xml2js": "0.4.3",
     "geostyler-style": "0.14.1",
     "lodash": "4.17.11",
     "xml2js": "0.4.19",
@@ -46,7 +44,9 @@
   "devDependencies": {
     "@babel/polyfill": "7.0.0",
     "@types/jest": "23.3.9",
+    "@types/lodash": "4.14.118",
     "@types/node": "10.12.2",
+    "@types/xml2js": "0.4.3",
     "awesome-typescript-loader": "4.0.1",
     "coveralls": "3.0.1",
     "jest": "23.4.2",


### PR DESCRIPTION
`@types/lodash` and `@types/xml2js` were set as dependencies instead of devDependencies. Fixed that.
