### PR TITLE
Added fillOpacity property. Fixes #915

### DIFF
--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -340,6 +340,16 @@ export class SldStyleParser implements StyleParser {
           break;
       }
     });
+    
+    fillParams.forEach((param: any) => {
+      switch (param.$.name) {
+        case 'fill-opacity':
+          markSymbolizer.fillOpacity = parseFloat(param._);
+          break;
+        default:
+         break;
+      }
+    });
 
     return markSymbolizer;
   }


### PR DESCRIPTION
Added fillOpacity property for new SLDParser().readStyle() response.
Fixes https://github.com/terrestris/geostyler/issues/915 .