### PR TITLE
Parse fontStyle and fontWeight

### DIFF
--- a/data/styles/multi_simplelineLabel.ts
+++ b/data/styles/multi_simplelineLabel.ts
@@ -15,7 +15,9 @@ const multiSimplelineLabel: Style = {
       label: '{{name}}',
       font: ['Arial'],
       size: 12,
-      offset: [0, 5]
+      offset: [0, 5],
+      fontStyle: 'normal',
+      fontWeight: 'bold'
     }]
   }]
 };

--- a/data/styles/point_styledLabel_literalPlaceholder.ts
+++ b/data/styles/point_styledLabel_literalPlaceholder.ts
@@ -13,7 +13,9 @@ const pointStyledLabel: Style = {
       offset: [0, 5],
       haloColor: '#000000',
       haloWidth: 5,
-      rotate: 45
+      rotate: 45,
+      fontStyle: 'normal',
+      fontWeight: 'bold'
     }]
   }]
 };

--- a/data/styles/point_styledlabel.ts
+++ b/data/styles/point_styledlabel.ts
@@ -13,7 +13,9 @@ const pointStyledLabel: Style = {
       offset: [0, 5],
       haloColor: '#000000',
       haloWidth: 5,
-      rotate: 45
+      rotate: 45,
+      fontStyle: 'normal',
+      fontWeight: 'bold'
     }]
   }]
 };

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -913,10 +913,10 @@ export class SldStyleParser implements StyleParser {
           textSymbolizer.font = [value];
           break;
         case 'font-style':
-          // Currently not supported by GeoStyler Style
+          textSymbolizer.fontStyle = value;
           break;
         case 'font-weight':
-          // Currently not supported by GeoStyler Style
+          textSymbolizer.fontWeight = value;
           break;
         case 'font-size':
           textSymbolizer.size = parseFloat(value);
@@ -1312,7 +1312,9 @@ export class SldStyleParser implements StyleParser {
 
     const fontPropertyMap = {
       font: 'font-family',
-      size: 'font-size'
+      size: 'font-size',
+      fontStyle: 'font-style',
+      fontWeight: 'font-weight'
     };
 
     const fontCssParameters: any[] = Object.keys(textSymbolizer)


### PR DESCRIPTION
**Important:** Please wait with merging this PR until
- [x] [this PR](https://github.com/terrestris/geostyler-style/pull/118) in `geostyler-style`
was merged and released.

This PR is based on https://github.com/terrestris/geostyler-sld-parser/pull/170, which does not seem to be maintained anymore.

Added reading and writing `fontStyle` and `fontWeight` properties of `TextSymbolizer`. Updated tests accordingly. 

closes https://github.com/terrestris/geostyler/issues/916