### PR TITLE
Introduces forceCasting flag

### DIFF
--- a/data/slds/line_graphicStroke.sld
+++ b/data/slds/line_graphicStroke.sld
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<StyledLayerDescriptor version="1.0.0"
-    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
-    xmlns="http://www.opengis.net/sld"
-    xmlns:ogc="http://www.opengis.net/ogc"
-    xmlns:xlink="http://www.w3.org/1999/xlink"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<StyledLayerDescriptor version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+  xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <NamedLayer>
     <Name>Simple Line</Name>
     <UserStyle>
@@ -31,7 +30,7 @@
               <CssParameter name="stroke-linejoin">mitre</CssParameter>
             </Stroke>
           </LineSymbolizer>
-       	</Rule>
+        </Rule>
       </FeatureTypeStyle>
     </UserStyle>
   </NamedLayer>

--- a/data/slds/line_simpleline.sld
+++ b/data/slds/line_simpleline.sld
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<StyledLayerDescriptor version="1.0.0"
-    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
-    xmlns="http://www.opengis.net/sld"
-    xmlns:ogc="http://www.opengis.net/ogc"
-    xmlns:xlink="http://www.w3.org/1999/xlink"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<StyledLayerDescriptor version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+  xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <NamedLayer>
     <Name>Simple Line</Name>
     <UserStyle>
@@ -21,7 +20,7 @@
               <CssParameter name="stroke-linejoin">mitre</CssParameter>
             </Stroke>
           </LineSymbolizer>
-       	</Rule>
+        </Rule>
       </FeatureTypeStyle>
     </UserStyle>
   </NamedLayer>

--- a/data/slds/point_simplecross.sld
+++ b/data/slds/point_simplecross.sld
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<StyledLayerDescriptor version="1.0.0"
-    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
-    xmlns="http://www.opengis.net/sld"
-    xmlns:ogc="http://www.opengis.net/ogc"
-    xmlns:xlink="http://www.w3.org/1999/xlink"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<StyledLayerDescriptor version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+  xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <NamedLayer>
     <Name>Simple Cross</Name>
     <UserStyle>
@@ -17,11 +16,11 @@
               <Mark>
                 <WellKnownName>cross</WellKnownName>
                 <Fill>
-                   <CssParameter name="fill">#FF0000</CssParameter>
+                  <CssParameter name="fill">#FF0000</CssParameter>
                 </Fill>
                 <Stroke>
-                   <CssParameter name="stroke">#000000</CssParameter>
-                   <CssParameter name="stroke-width">2</CssParameter>
+                  <CssParameter name="stroke">#000000</CssParameter>
+                  <CssParameter name="stroke-width">2</CssParameter>
                 </Stroke>
               </Mark>
               <Size>10</Size>

--- a/data/slds/point_simplepoint_filter.sld
+++ b/data/slds/point_simplepoint_filter.sld
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<StyledLayerDescriptor version="1.0.0"
-    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
-    xmlns="http://www.opengis.net/sld"
-    xmlns:ogc="http://www.opengis.net/ogc"
-    xmlns:xlink="http://www.w3.org/1999/xlink"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<StyledLayerDescriptor version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+  xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <NamedLayer>
     <Name>Simple Point Filter</Name>
     <UserStyle>
@@ -58,11 +57,11 @@
               <Mark>
                 <WellKnownName>circle</WellKnownName>
                 <Fill>
-                   <CssParameter name="fill">#FF0000</CssParameter>
+                  <CssParameter name="fill">#FF0000</CssParameter>
                 </Fill>
                 <Stroke>
-                   <CssParameter name="stroke">#000000</CssParameter>
-                   <CssParameter name="stroke-width">2</CssParameter>
+                  <CssParameter name="stroke">#000000</CssParameter>
+                  <CssParameter name="stroke-width">2</CssParameter>
                 </Stroke>
               </Mark>
               <Size>6</Size>

--- a/data/slds/point_simplepoint_nestedLogicalFilters.sld
+++ b/data/slds/point_simplepoint_nestedLogicalFilters.sld
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<StyledLayerDescriptor version="1.0.0"
-    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
-    xmlns="http://www.opengis.net/sld"
-    xmlns:ogc="http://www.opengis.net/ogc"
-    xmlns:xlink="http://www.w3.org/1999/xlink"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<StyledLayerDescriptor version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+  xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <NamedLayer>
     <Name>Simple Point Filter</Name>
     <UserStyle>
@@ -53,11 +52,11 @@
               <Mark>
                 <WellKnownName>circle</WellKnownName>
                 <Fill>
-                   <CssParameter name="fill">#FF0000</CssParameter>
+                  <CssParameter name="fill">#FF0000</CssParameter>
                 </Fill>
                 <Stroke>
-                   <CssParameter name="stroke">#000000</CssParameter>
-                   <CssParameter name="stroke-width">2</CssParameter>
+                  <CssParameter name="stroke">#000000</CssParameter>
+                  <CssParameter name="stroke-width">2</CssParameter>
                 </Stroke>
               </Mark>
               <Size>6</Size>

--- a/data/slds/point_simpleslash.sld
+++ b/data/slds/point_simpleslash.sld
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<StyledLayerDescriptor version="1.0.0"
-    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
-    xmlns="http://www.opengis.net/sld"
-    xmlns:ogc="http://www.opengis.net/ogc"
-    xmlns:xlink="http://www.w3.org/1999/xlink"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<StyledLayerDescriptor version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+  xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <NamedLayer>
     <Name>Simple Slash</Name>
     <UserStyle>
@@ -17,11 +16,11 @@
               <Mark>
                 <WellKnownName>shape://slash</WellKnownName>
                 <Fill>
-                   <CssParameter name="fill">#FF0000</CssParameter>
+                  <CssParameter name="fill">#FF0000</CssParameter>
                 </Fill>
                 <Stroke>
-                   <CssParameter name="stroke">#000000</CssParameter>
-                   <CssParameter name="stroke-width">2</CssParameter>
+                  <CssParameter name="stroke">#000000</CssParameter>
+                  <CssParameter name="stroke-width">2</CssParameter>
                 </Stroke>
               </Mark>
               <Size>10</Size>

--- a/data/slds/point_simplesquare.sld
+++ b/data/slds/point_simplesquare.sld
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<StyledLayerDescriptor version="1.0.0"
-    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
-    xmlns="http://www.opengis.net/sld"
-    xmlns:ogc="http://www.opengis.net/ogc"
-    xmlns:xlink="http://www.w3.org/1999/xlink"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<StyledLayerDescriptor version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+  xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <NamedLayer>
     <Name>Simple Square</Name>
     <UserStyle>
@@ -17,11 +16,11 @@
               <Mark>
                 <WellKnownName>square</WellKnownName>
                 <Fill>
-                   <CssParameter name="fill">#FF0000</CssParameter>
+                  <CssParameter name="fill">#FF0000</CssParameter>
                 </Fill>
                 <Stroke>
-                   <CssParameter name="stroke">#000000</CssParameter>
-                   <CssParameter name="stroke-width">2</CssParameter>
+                  <CssParameter name="stroke">#000000</CssParameter>
+                  <CssParameter name="stroke-width">2</CssParameter>
                 </Stroke>
               </Mark>
               <Size>10</Size>

--- a/data/slds/point_simplestar.sld
+++ b/data/slds/point_simplestar.sld
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<StyledLayerDescriptor version="1.0.0"
-    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
-    xmlns="http://www.opengis.net/sld"
-    xmlns:ogc="http://www.opengis.net/ogc"
-    xmlns:xlink="http://www.w3.org/1999/xlink"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<StyledLayerDescriptor version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+  xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <NamedLayer>
     <Name>Simple Star</Name>
     <UserStyle>
@@ -17,11 +16,11 @@
               <Mark>
                 <WellKnownName>star</WellKnownName>
                 <Fill>
-                   <CssParameter name="fill">#FF0000</CssParameter>
+                  <CssParameter name="fill">#FF0000</CssParameter>
                 </Fill>
                 <Stroke>
-                   <CssParameter name="stroke">#000000</CssParameter>
-                   <CssParameter name="stroke-width">2</CssParameter>
+                  <CssParameter name="stroke">#000000</CssParameter>
+                  <CssParameter name="stroke-width">2</CssParameter>
                 </Stroke>
               </Mark>
               <Size>10</Size>

--- a/data/slds/point_simpletriangle.sld
+++ b/data/slds/point_simpletriangle.sld
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<StyledLayerDescriptor version="1.0.0"
-    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
-    xmlns="http://www.opengis.net/sld"
-    xmlns:ogc="http://www.opengis.net/ogc"
-    xmlns:xlink="http://www.w3.org/1999/xlink"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<StyledLayerDescriptor version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+  xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <NamedLayer>
     <Name>Simple Triangle</Name>
     <UserStyle>
@@ -17,11 +16,11 @@
               <Mark>
                 <WellKnownName>triangle</WellKnownName>
                 <Fill>
-                   <CssParameter name="fill">#FF0000</CssParameter>
+                  <CssParameter name="fill">#FF0000</CssParameter>
                 </Fill>
                 <Stroke>
-                   <CssParameter name="stroke">#000000</CssParameter>
-                   <CssParameter name="stroke-width">2</CssParameter>
+                  <CssParameter name="stroke">#000000</CssParameter>
+                  <CssParameter name="stroke-width">2</CssParameter>
                 </Stroke>
               </Mark>
               <Size>10</Size>

--- a/data/slds/point_simplex.sld
+++ b/data/slds/point_simplex.sld
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<StyledLayerDescriptor version="1.0.0"
-    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
-    xmlns="http://www.opengis.net/sld"
-    xmlns:ogc="http://www.opengis.net/ogc"
-    xmlns:xlink="http://www.w3.org/1999/xlink"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<StyledLayerDescriptor version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+  xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <NamedLayer>
     <Name>Simple X</Name>
     <UserStyle>
@@ -17,11 +16,11 @@
               <Mark>
                 <WellKnownName>x</WellKnownName>
                 <Fill>
-                   <CssParameter name="fill">#FF0000</CssParameter>
+                  <CssParameter name="fill">#FF0000</CssParameter>
                 </Fill>
                 <Stroke>
-                   <CssParameter name="stroke">#000000</CssParameter>
-                   <CssParameter name="stroke-width">2</CssParameter>
+                  <CssParameter name="stroke">#000000</CssParameter>
+                  <CssParameter name="stroke-width">2</CssParameter>
                 </Stroke>
               </Mark>
               <Size>10</Size>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geostyler-sld-parser",
-  "version": "0.18.2",
+  "version": "1.0.0",
   "description": "GeoStyler Style Parser implementation for SLD",
   "main": "build/dist/SldStyleParser.js",
   "files": [

--- a/src/SldStyleParser.spec.ts
+++ b/src/SldStyleParser.spec.ts
@@ -619,7 +619,6 @@ describe('SldStyleParser implements StyleParser', () => {
             .then(readStyle => {
               expect(readStyle).toEqual(raster_simpleraster);
             });
-        })
         });
     });
     it('can write a complex SLD RasterSymbolizer', () => {
@@ -633,7 +632,6 @@ describe('SldStyleParser implements StyleParser', () => {
             .then(readStyle => {
               expect(readStyle).toEqual(raster_complexraster);
             });
-        })
         });
     });
     it('can write a SLD style with a filter', () => {
@@ -664,10 +662,39 @@ describe('SldStyleParser implements StyleParser', () => {
             });
         });
     });
+    it('can write a SLD style with a filter and force cast of numeric fields (forceCasting)', () => {
+      expect.assertions(2);
+      styleParser.forceCasting = true;
+      return styleParser.writeStyle(point_simplepoint_filter_forceNumerics)
+        .then((sldString: string) => {
+          expect(sldString).toBeDefined();
+          // As string comparison between to XML-Strings is awkward and nonesens
+          // we read it again and compare the json input with the parser output
+          return styleParser.readStyle(sldString)
+            .then(readStyle => {
+              expect(readStyle).toEqual(point_simplepoint_filter_forceNumerics);
+            });
+        });
+    });
     it('can write a SLD style with a filter and force cast of boolean fields', () => {
       expect.assertions(2);
       // force fields beeing casted to boolean data type
       styleParser.boolFilterFields = ['TEST', 'TEST2'];
+      return styleParser.writeStyle(point_simplepoint_filter_forceBools)
+        .then((sldString: string) => {
+          expect(sldString).toBeDefined();
+          // As string comparison between to XML-Strings is awkward and nonesens
+          // we read it again and compare the json input with the parser output
+          return styleParser.readStyle(sldString)
+            .then(readStyle => {
+              expect(readStyle).toEqual(point_simplepoint_filter_forceBools);
+            });
+        });
+    });
+    it('can write a SLD style with a filter and force cast of boolean fields (forceCasting)', () => {
+      expect.assertions(2);
+      // force fields beeing casted to boolean data type
+      styleParser.forceCasting = true;
       return styleParser.writeStyle(point_simplepoint_filter_forceBools)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();

--- a/src/SldStyleParser.spec.ts
+++ b/src/SldStyleParser.spec.ts
@@ -620,6 +620,7 @@ describe('SldStyleParser implements StyleParser', () => {
               expect(readStyle).toEqual(raster_simpleraster);
             });
         })
+        });
     });
     it('can write a complex SLD RasterSymbolizer', () => {
       expect.assertions(2);
@@ -633,6 +634,7 @@ describe('SldStyleParser implements StyleParser', () => {
               expect(readStyle).toEqual(raster_complexraster);
             });
         })
+        });
     });
     it('can write a SLD style with a filter', () => {
       expect.assertions(2);
@@ -762,7 +764,7 @@ describe('SldStyleParser implements StyleParser', () => {
     describe('#getSldRasterSymbolizerFromRasterSymbolizer', () => {
       it('is defined', () => {
         expect(styleParser.getSldRasterSymbolizerFromRasterSymbolizer).toBeDefined();
-      })
+      });
     });
 
     describe('#getSldComparisonFilterFromComparisonFilte', () => {

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -110,6 +110,27 @@ export class SldStyleParser implements StyleParser {
   }
 
   /**
+   * Flag to tell if all values should be casted automatically
+   */
+  private _forceCasting: boolean = false;
+
+  /**
+   * Getter for _forceCasting
+   * @return {boolean}
+   */
+  get forceCasting(): boolean {
+    return this._forceCasting;
+  }
+
+  /**
+   * Setter for _forceCasting
+   * @param {boolean} forceCasting The forceCasting value to set
+   */
+  set forceCasting(forceCasting: boolean) {
+    this._forceCasting = forceCasting;
+  }
+
+  /**
    * Returns the keys of an object where the value is equal to the passed in
    * value.
    *
@@ -165,12 +186,13 @@ export class SldStyleParser implements StyleParser {
       if (sldOperatorName !== 'PropertyIsNull') {
         value = sldFilter.Literal[0];
       }
-      if (this.numericFilterFields.indexOf(property) !== -1 && !Number.isNaN(parseFloat(value))) {
+      const shouldParse = this.numericFilterFields.indexOf(property) !== -1 || this.forceCasting;
+      if (shouldParse && !Number.isNaN(parseFloat(value))) {
         value = parseFloat(value);
       }
       if (_isString(value)) {
         const lowerValue = value.toLowerCase();
-        if (this.boolFilterFields.indexOf(property) !== -1) {
+        if (this.boolFilterFields.indexOf(property) !== -1 || this.forceCasting) {
           if (lowerValue === 'false') {value = false; }
           if (lowerValue === 'true') {value = true; }
         }
@@ -638,7 +660,7 @@ export class SldStyleParser implements StyleParser {
       contrastEnhancement.enhancementType = 'histogram';
     } else if (hasNormalize) {
       contrastEnhancement.enhancementType = 'normalize';
-    } 
+    }
     // parse gammavalue
     let gammaValue = _get(sldContrastEnhancement, 'GammaValue[0]');
     if (gammaValue) {

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -34,6 +34,12 @@ const _get = require('lodash/get');
 const _set = require('lodash/set');
 const _isEmpty = require('lodash/isEmpty');
 
+export type ConstructorParams = {
+  forceCasting?: boolean,
+  numericFilterFields?: string[],
+  boolFilterFields?: string[]
+};
+
 /**
  * This parser can be used with the GeoStyler.
  * It implements the GeoStyler-Style StyleParser interface.
@@ -68,6 +74,10 @@ export class SldStyleParser implements StyleParser {
     PropertyIsGreaterThanOrEqualTo: '>=',
     PropertyIsNull: '=='
   };
+
+  constructor(opts?: ConstructorParams) {
+    Object.assign(this, opts);
+  }
 
   /**
    * Array of field / property names in a filter, which are casted to numerics


### PR DESCRIPTION
This PR introduces the `forceCasting` flag.

If set to `true` the SLDParser will try to cast all numeric or boolean like values to its datatypes.

Compare https://github.com/terrestris/geostyler-sld-parser/pull/127#issuecomment-486221366 for reference.

This also introduces the `ConstructorParams` type to allow setting `forceCasting`, `boolFilterFields`, and `numericFilterFields` when instantiating the parser.