### PR TITLE
Custom Comparison Filter Stopgap

### DIFF
--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -1904,6 +1904,13 @@ export class SldStyleParser implements StyleParser {
     let sldOperator: string = (sldOperators.length > 1 && value === null)
       ? sldOperators[1] : sldOperators[0];
 
+    // allow for more complex filters within comparison filters
+    // (this is a stopgap until filters are natively supported)
+    // see https://github.com/terrestris/geostyler/issues/996
+    if (comparisonFilter.length === 2 && typeof key === 'object') {
+      sldComparisonFilter[sldOperator] = [key]; // key must be an object readable with xml2js
+    }
+    
     if (sldOperator === 'PropertyIsNull') {
       // empty, selfclosing Literals are not valid in a propertyIsNull filter
       sldComparisonFilter[sldOperator] = [{


### PR DESCRIPTION
Allow custom comparison filter expressions with an xml2js readable object. Usage would look like this:

```javascript
filter: ['||',
  ['*=', {
    'Function': {
      $: { name: 'strMatches' },
      'PropertyName': 'year',
      'Literal': '^( )??2019,.*'
    },
    'Literal': 'true'
  }, {
    'Function': {
      $: { name: 'strMatches' },
      'PropertyName': 'year',
      'Literal': '.*,( )??2019( )??,.*'
    },
    'Literal': 'true'
  }]
]
```

It's basically just an xml2js object passed in for index `1` which can then be properly serialized by xml2js. I'm happy to write some tests for this too. I'm mobile ATM.