### PR TITLE
Introduces parsing of strMatches FunctionFilter

### DIFF
--- a/data/slds/point_simplepoint_functionfilter.sld
+++ b/data/slds/point_simplepoint_functionfilter.sld
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+  xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NamedLayer>
+    <Name>Simple Point Filter</Name>
+    <UserStyle>
+      <Title>Simple Point Filter</Title>
+      <FeatureTypeStyle>
+        <Rule>
+          <Name>Small populated New Yorks</Name>
+          <Filter xmlns="http://www.opengis.net/ogc">
+            <PropertyIsLike>
+              <Function name="strMatches">
+                <PropertyName>year</PropertyName>
+                <Literal>^( )??2019,.*</Literal>
+              </Function>
+              <Literal>true</Literal>
+            </PropertyIsLike>
+          </Filter>
+          <MinScaleDenominator>10000</MinScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
+          <PointSymbolizer>
+            <Graphic>
+              <Mark>
+                <WellKnownName>circle</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#FF0000</CssParameter>
+                </Fill>
+                <Stroke>
+                  <CssParameter name="stroke">#000000</CssParameter>
+                  <CssParameter name="stroke-width">2</CssParameter>
+                </Stroke>
+              </Mark>
+              <Size>6</Size>
+            </Graphic>
+          </PointSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/data/styles/point_simplepoint_functionfilter.ts
+++ b/data/styles/point_simplepoint_functionfilter.ts
@@ -1,0 +1,27 @@
+import { Style } from 'geostyler-style';
+
+const pointSimplePoint: Style = {
+  'name': 'Simple Point Filter',
+  'rules': [{
+    'filter': [
+      '*=',
+      ['FN_strMatches', 'year', /^( )??2019,.*/],
+      true
+    ],
+    'name': 'Small populated New Yorks',
+    'scaleDenominator': {
+      'max': 20000,
+      'min': 10000
+    },
+    'symbolizers': [{
+      'kind': 'Mark',
+      'wellKnownName': 'Circle',
+      'color': '#FF0000',
+      'radius': 3,
+      'strokeColor': '#000000',
+      'strokeWidth': 2
+    }]
+  }]
+};
+
+export default pointSimplePoint;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/terrestris/geostyler-sld-parser#readme",
   "dependencies": {
-    "geostyler-style": "1.1.0",
+    "geostyler-style": "1.2.0",
     "lodash": "4.17.11",
     "xml2js": "0.4.19",
     "xmldom": "0.1.27"

--- a/src/SldStyleParser.spec.ts
+++ b/src/SldStyleParser.spec.ts
@@ -376,7 +376,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(point_simplepoint)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {
@@ -389,7 +389,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(point_externalgraphic)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {
@@ -402,7 +402,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(point_externalgraphic_svg)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {
@@ -415,7 +415,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(point_simplesquare)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {
@@ -428,7 +428,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(point_simpletriangle)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {
@@ -441,7 +441,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(point_simplestar)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {
@@ -454,7 +454,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(point_simplecross)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {
@@ -467,7 +467,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(point_simplex)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {
@@ -480,7 +480,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(point_simpleslash)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {
@@ -493,7 +493,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(line_simpleline)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {
@@ -506,7 +506,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(line_perpendicularOffset)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {
@@ -519,7 +519,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(line_graphicStroke)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {
@@ -532,7 +532,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(line_graphicStroke_externalGraphic)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {
@@ -545,7 +545,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(line_graphicFill)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {
@@ -558,7 +558,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(line_graphicFill_externalGraphic)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {
@@ -571,7 +571,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(polygon_transparentpolygon)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {
@@ -584,7 +584,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(polygon_graphicFill)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {
@@ -597,7 +597,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(polygon_graphicFill_externalGraphic)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {
@@ -610,7 +610,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(point_styledlabel)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {
@@ -623,7 +623,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(raster_simpleraster)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {
@@ -636,7 +636,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(raster_complexraster)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {
@@ -649,7 +649,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(point_simplepoint_filter)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {
@@ -664,7 +664,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(point_simplepoint_filter_forceNumerics)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {
@@ -678,7 +678,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(point_simplepoint_filter_forceNumerics)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {
@@ -693,7 +693,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(point_simplepoint_filter_forceBools)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {
@@ -708,7 +708,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(point_simplepoint_filter_forceBools)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {
@@ -721,7 +721,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(point_simplepoint_nestedLogicalFilters)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {
@@ -734,7 +734,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(point_simplepoint_functionfilter)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {
@@ -747,7 +747,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(multi_simplelineLabel)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {
@@ -760,7 +760,7 @@ describe('SldStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(point_styledLabel_literalPlaceholder)
         .then((sldString: string) => {
           expect(sldString).toBeDefined();
-          // As string comparison between to XML-Strings is awkward and nonesens
+          // As string comparison between two XML-Strings is awkward and nonsens
           // we read it again and compare the json input with the parser output
           return styleParser.readStyle(sldString)
             .then(readStyle => {

--- a/src/SldStyleParser.spec.ts
+++ b/src/SldStyleParser.spec.ts
@@ -16,6 +16,7 @@ import point_styledlabel from '../data/styles/point_styledlabel';
 import point_simplepoint_filter from '../data/styles/point_simplepoint_filter';
 import point_simplepoint_filter_forceBools from '../data/styles/point_simplepoint_filter_forceBools';
 import point_simplepoint_filter_forceNumerics from '../data/styles/point_simplepoint_filter_forceNumerics';
+import point_simplepoint_functionfilter from '../data/styles/point_simplepoint_functionfilter';
 import point_simplepoint_nestedLogicalFilters from '../data/styles/point_simplepoint_nestedLogicalFilters';
 import point_externalgraphic from '../data/styles/point_externalgraphic';
 import point_externalgraphic_svg from '../data/styles/point_externalgraphic_svg';
@@ -263,6 +264,15 @@ describe('SldStyleParser implements StyleParser', () => {
         .then((geoStylerStyle: Style) => {
           expect(geoStylerStyle).toBeDefined();
           expect(geoStylerStyle).toEqual(point_simplepoint_nestedLogicalFilters);
+        });
+    });
+    it('can read a SLD style with functionfilters', () => {
+      expect.assertions(2);
+      const sld = fs.readFileSync( './data/slds/point_simplepoint_functionfilter.sld', 'utf8');
+      return styleParser.readStyle(sld)
+        .then((geoStylerStyle: Style) => {
+          expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(point_simplepoint_functionfilter);
         });
     });
     it('can read a SLD style with multiple symbolizers in one Rule', () => {
@@ -716,6 +726,19 @@ describe('SldStyleParser implements StyleParser', () => {
           return styleParser.readStyle(sldString)
             .then(readStyle => {
               expect(readStyle).toEqual(point_simplepoint_nestedLogicalFilters);
+            });
+        });
+    });
+    it('can write a SLD style with functionfilters', () => {
+      expect.assertions(2);
+      return styleParser.writeStyle(point_simplepoint_functionfilter)
+        .then((sldString: string) => {
+          expect(sldString).toBeDefined();
+          // As string comparison between to XML-Strings is awkward and nonesens
+          // we read it again and compare the json input with the parser output
+          return styleParser.readStyle(sldString)
+            .then(readStyle => {
+              expect(readStyle).toEqual(point_simplepoint_functionfilter);
             });
         });
     });

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -198,7 +198,7 @@ export class SldStyleParser implements StyleParser {
   }
 
   /**
-   * Creates a GeoStyler-Style FunctionFilterr from a SLD Function.
+   * Creates a GeoStyler-Style FunctionFilter from a SLD Function.
    *
    * @param {object} sldFilter The SLD Filter
    * @return {Filter} The GeoStyler-Style FunctionFilter


### PR DESCRIPTION
This introduces the parsing of the `strMatches` Function for SLDs.

@glenselle Would be nice if you could test if this suites all your need as described in #195 and in 
https://github.com/terrestris/geostyler/issues/996.

Closes #195 