### PR TITLE
Use parseFloat to parse symbolizer values

### DIFF
--- a/data/slds/point_externalgraphic_floatingPoint.sld
+++ b/data/slds/point_externalgraphic_floatingPoint.sld
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0"
+    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+    xmlns="http://www.opengis.net/sld"
+    xmlns:ogc="http://www.opengis.net/ogc"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NamedLayer>
+    <Name>External Graphic</Name>
+    <UserStyle>
+      <Title>External Graphic</Title>
+      <FeatureTypeStyle>
+        <Rule>
+          <PointSymbolizer>
+              <Graphic>
+                  <ExternalGraphic>
+                      <OnlineResource xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://geoserver.org/img/geoserver-logo.png" />
+                      <Format>image/png</Format>
+                  </ExternalGraphic>
+                  <Size>0.1</Size>
+                  <Rotation>90.5</Rotation>
+              </Graphic>
+          </PointSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/data/styles/point_externalgraphic_floatingPoint.ts
+++ b/data/styles/point_externalgraphic_floatingPoint.ts
@@ -1,0 +1,16 @@
+import { Style } from 'geostyler-style';
+
+const pointExternalGraphic: Style = {
+  name: 'External Graphic',
+  rules: [{
+    name: '',
+    symbolizers: [{
+      kind: 'Icon',
+      image: 'http://geoserver.org/img/geoserver-logo.png',
+      size: 0.1,
+      rotate: 90.5
+    }]
+  }]
+};
+
+export default pointExternalGraphic;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geostyler-sld-parser",
-  "version": "1.3.1",
+  "version": "1.3.0",
   "description": "GeoStyler Style Parser implementation for SLD",
   "main": "build/dist/SldStyleParser.js",
   "types": "build/dist/SldStyleParser.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geostyler-sld-parser",
-  "version": "1.2.0",
+  "version": "1.3.1",
   "description": "GeoStyler Style Parser implementation for SLD",
   "main": "build/dist/SldStyleParser.js",
   "types": "build/dist/SldStyleParser.d.ts",

--- a/src/SldStyleParser.spec.ts
+++ b/src/SldStyleParser.spec.ts
@@ -19,6 +19,7 @@ import point_simplepoint_filter_forceNumerics from '../data/styles/point_simplep
 import point_simplepoint_functionfilter from '../data/styles/point_simplepoint_functionfilter';
 import point_simplepoint_nestedLogicalFilters from '../data/styles/point_simplepoint_nestedLogicalFilters';
 import point_externalgraphic from '../data/styles/point_externalgraphic';
+import point_externalgraphic_floatingPoint from '../data/styles/point_externalgraphic_floatingPoint';
 import point_externalgraphic_svg from '../data/styles/point_externalgraphic_svg';
 import multi_simplelineLabel from '../data/styles/multi_simplelineLabel';
 import point_simplesquare from '../data/styles/point_simplesquare';
@@ -75,6 +76,15 @@ describe('SldStyleParser implements StyleParser', () => {
         .then((geoStylerStyle: Style) => {
           expect(geoStylerStyle).toBeDefined();
           expect(geoStylerStyle).toEqual(point_externalgraphic);
+        });
+      });
+    it('can read a SLD PointSymbolizer with ExternalGraphic with floating-point values', () => {
+      expect.assertions(2);
+      const sld = fs.readFileSync( './data/slds/point_externalgraphic_floatingPoint.sld', 'utf8');
+      return styleParser.readStyle(sld)
+        .then((geoStylerStyle: Style) => {
+          expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(point_externalgraphic_floatingPoint);
         });
       });
     it('can read a SLD PointSymbolizer with ExternalGraphic svg', () => {

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -472,10 +472,10 @@ export class SldStyleParser implements StyleParser {
       iconSymbolizer.opacity = opacity;
     }
     if (size) {
-      iconSymbolizer.size = parseInt(size, 10);
+      iconSymbolizer.size = parseFloat(size);
     }
     if (rotate) {
-      iconSymbolizer.rotate = parseInt(rotate, 10);
+      iconSymbolizer.rotate = parseFloat(rotate);
     }
 
     return iconSymbolizer;
@@ -655,12 +655,12 @@ export class SldStyleParser implements StyleParser {
       if (name === 'stroke') {
         fillSymbolizer.outlineColor = value;
       } else if (name === 'stroke-width') {
-        fillSymbolizer.outlineWidth = parseInt(value, 10);
+        fillSymbolizer.outlineWidth = parseFloat(value);
       } else if (name === 'stroke-dasharray') {
         const outlineDasharrayStr = value.split(' ');
         const outlineDasharray: number[] = [];
         outlineDasharrayStr.forEach((dashStr: string) => {
-          outlineDasharray.push(parseInt(dashStr, 10));
+          outlineDasharray.push(parseFloat(dashStr));
         });
         fillSymbolizer.outlineDasharray = outlineDasharray;
       }


### PR DESCRIPTION
Required for / fixes https://github.com/terrestris/geostyler/issues/995. The usage of `parseFloat` allows setting non-integer values.

The OGC SE specification also allows floating-point values for these attributes.

@terrestris/devs Please review