### PR TITLE
Remove deprecated tslint rule "no-unused-variable"

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -43,7 +43,6 @@
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": false,
     "no-unused-expression": true,
-    "no-unused-variable": true,
     "no-use-before-declare": true,
     "one-line": [
       true,


### PR DESCRIPTION
This removes the deprecated tslint rule `no-unused-variable`. Check [here](https://github.com/palantir/tslint/blob/master/CHANGELOG.md#warning-deprecations) or https://github.com/palantir/tslint/issues/4046 for more information.