### PR TITLE
Fix displacement-offset conversion and update geostyler-style

### DIFF
--- a/data/slds/1.0/text_displacement.sld
+++ b/data/slds/1.0/text_displacement.sld
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor
+  version="1.0.0"
+  xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd"
+  xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+>
+  <NamedLayer>
+    <Name>Displaced Text</Name>
+    <UserStyle>
+      <Name>Displaced Text</Name>
+      <FeatureTypeStyle>
+        <Rule>
+          <Name/>
+          <TextSymbolizer>
+            <Label>Displaced</Label>
+            <LabelPlacement>
+              <PointPlacement>
+                <Displacement>
+                  <DisplacementX>-20</DisplacementX>
+                  <DisplacementY>10</DisplacementY>
+                </Displacement>
+              </PointPlacement>
+            </LabelPlacement>
+          </TextSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/data/styles/geoserver/poi.ts
+++ b/data/styles/geoserver/poi.ts
@@ -21,7 +21,7 @@ const style: Style = {
           radius: 3.5,
           offset: [
             5,
-            10
+            -10
           ],
         }
       ]

--- a/data/styles/point_simplepoint_displacement.ts
+++ b/data/styles/point_simplepoint_displacement.ts
@@ -12,7 +12,7 @@ const pointSimplePointDisplacement: Style = {
       fillOpacity: 0.5,
       strokeColor: '#0000FF',
       strokeOpacity: 0.7,
-      offset: [13, 37]
+      offset: [13, -37]
     }]
   }]
 };

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "fast-xml-parser": "^5.2.3",
-    "geostyler-style": "^11.0.1",
+    "geostyler-style": "^11.0.2",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/src/SldParser.spec.ts
+++ b/src/SldParser.spec.ts
@@ -8,10 +8,11 @@ import { expect, it, describe } from 'vitest';
 import point_simplepoint from '../data/styles/point_simplepoint';
 // @ts-ignore
 import cdata from '../data/styles/cdata';
+import { TextSymbolizer } from 'geostyler-style';
 
 describe('SldStyleParser implements StyleParser (reading from one version and writing to another version)', () => {
   it('can read and write a SLD PointSymbolizer (from 1.0.0 version to 1.1.0 version)', async () => {
-    const styleParser = new SldStyleParser({sldVersion: '1.1.0'});
+    const styleParser = new SldStyleParser({ sldVersion: '1.1.0' });
 
     const sld = fs.readFileSync('./data/slds/1.0/point_simplepoint.sld', 'utf8');
     const { output: geoStylerStyle } = await styleParser.readStyle(sld);
@@ -32,7 +33,7 @@ describe('SldStyleParser implements StyleParser (reading from one version and wr
     expect(readStyle).toEqual(point_simplepoint);
   });
   it('can read and write a SLD PointSymbolizer (from 1.1.0 version to 1.0.0 version)', async () => {
-    const styleParser = new SldStyleParser({sldVersion: '1.0.0'});
+    const styleParser = new SldStyleParser({ sldVersion: '1.0.0' });
 
     const sld = fs.readFileSync('./data/slds/1.1/point_simplepoint.sld', 'utf8');
     const { output: geoStylerStyle } = await styleParser.readStyle(sld);
@@ -67,33 +68,54 @@ describe('SldStyleParser implements StyleParser (reading from one version and wr
 
 describe('Test Anchor-Point-Conversions', () => {
   it('transforms the sld-Anchorpoint-values to geostyler-anchors', async () => {
-    const test1 = new SldStyleParser().getAnchorFromSldAnchorPoint(0.0,0.0);
+    const test1 = new SldStyleParser().getAnchorFromSldAnchorPoint(0.0, 0.0);
     expect(test1).toEqual('bottom-left');
-    const test2 = new SldStyleParser().getAnchorFromSldAnchorPoint(1.0,1.0);
+    const test2 = new SldStyleParser().getAnchorFromSldAnchorPoint(1.0, 1.0);
     expect(test2).toEqual('top-right');
-    const test3 = new SldStyleParser().getAnchorFromSldAnchorPoint(0.5,1.0);
+    const test3 = new SldStyleParser().getAnchorFromSldAnchorPoint(0.5, 1.0);
     expect(test3).toEqual('top');
-    const test4 = new SldStyleParser().getAnchorFromSldAnchorPoint(0.45,0.9);
+    const test4 = new SldStyleParser().getAnchorFromSldAnchorPoint(0.45, 0.9);
     expect(test4).toEqual('top');
-    const test5 = new SldStyleParser().getAnchorFromSldAnchorPoint(0.5,0.5);
+    const test5 = new SldStyleParser().getAnchorFromSldAnchorPoint(0.5, 0.5);
     expect(test5).toBeUndefined();
-    const test6 = new SldStyleParser().getAnchorFromSldAnchorPoint(undefined,undefined);
+    const test6 = new SldStyleParser().getAnchorFromSldAnchorPoint(undefined, undefined);
     expect(test6).toBeUndefined();
   });
   it('transformes the geostyler-anchors to sld-Anchopoint-values', async () => {
-    const test1 = new SldStyleParser().getSldAnchorPointFromAnchor('bottom-left','x');
+    const test1 = new SldStyleParser().getSldAnchorPointFromAnchor('bottom-left', 'x');
     expect(test1).toEqual(0.0);
-    const test2 = new SldStyleParser().getSldAnchorPointFromAnchor('bottom-left','y');
+    const test2 = new SldStyleParser().getSldAnchorPointFromAnchor('bottom-left', 'y');
     expect(test2).toEqual(0.0);
-    const test3 = new SldStyleParser().getSldAnchorPointFromAnchor('bottom','x');
+    const test3 = new SldStyleParser().getSldAnchorPointFromAnchor('bottom', 'x');
     expect(test3).toEqual(0.5);
-    const test4 = new SldStyleParser().getSldAnchorPointFromAnchor('bottom','y');
+    const test4 = new SldStyleParser().getSldAnchorPointFromAnchor('bottom', 'y');
     expect(test4).toEqual(0.0);
-    const test5 = new SldStyleParser().getSldAnchorPointFromAnchor('center','x');
+    const test5 = new SldStyleParser().getSldAnchorPointFromAnchor('center', 'x');
     expect(test5).toEqual(0.5);
-    const test6 = new SldStyleParser().getSldAnchorPointFromAnchor('center','y');
+    const test6 = new SldStyleParser().getSldAnchorPointFromAnchor('center', 'y');
     expect(test6).toEqual(0.5);
-    const test7 = new SldStyleParser().getAnchorFromSldAnchorPoint(undefined,'x');
+    const test7 = new SldStyleParser().getAnchorFromSldAnchorPoint(undefined, 'x');
     expect(test7).toBeUndefined();
+  });
+});
+
+describe('Diplacement parsing works with `pareTagValue: false` option', async () => {
+  let styleParser: SldStyleParser;
+  it('parses the displacement values as numbers', async () => {
+    const sld = fs.readFileSync('./data/slds/1.0/text_displacement.sld', 'utf8');
+    styleParser = new SldStyleParser({
+      sldVersion: '1.0.0',
+      parserOptions: {
+        parseTagValue: false
+      }
+    });
+    const { output: geoStylerStyle } = await styleParser.readStyle(sld);
+    expect(geoStylerStyle).toBeDefined();
+    const symbolizer = geoStylerStyle?.rules?.[0]?.symbolizers?.[0] as TextSymbolizer;
+    expect(symbolizer).toBeDefined();
+    // beware that in SLD positive y values mean a displacement to the top,
+    // whereas in geostyler-style positive y values mean a displacement to the bottom,
+    // thus the y value is inverted
+    expect(symbolizer.offset).toEqual([-20, -10]);
   });
 });

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -35,7 +35,8 @@ import {
   UnsupportedProperties,
   WellKnownName,
   WriteStyleResult,
-  DistanceUnit
+  DistanceUnit,
+  BasePointSymbolizer
 } from 'geostyler-style';
 import {
   X2jOptions,
@@ -70,18 +71,18 @@ const SLD_ENVIRONMENTS = [sldEnvGeoServer] as const;
 export type SldEnvironment = (typeof SLD_ENVIRONMENTS)[number];
 
 export type ParserOptions = Omit<X2jOptions,
-'ignoreDeclaration' |
-'removeNSPrefix' |
-'ignoreAttributes' |
-'preserveOrder' |
-'trimValues'
+  'ignoreDeclaration' |
+  'removeNSPrefix' |
+  'ignoreAttributes' |
+  'preserveOrder' |
+  'trimValues'
 >;
 
 export type BuilderOptions = Omit<XmlBuilderOptions,
-'cdataPropName' |
-'ignoreAttributes' |
-'suppressEmptyNode' |
-'preserveOrder'
+  'cdataPropName' |
+  'ignoreAttributes' |
+  'suppressEmptyNode' |
+  'preserveOrder'
 >;
 
 export type ConstructorParams = {
@@ -138,9 +139,9 @@ const ARITHMETIC_OPERATORS = [
 type ArithmeticType = typeof ARITHMETIC_OPERATORS[number];
 
 export type SldStyleParserTranslationKeys = {
-  marksymbolizerParseFailedUnknownWellknownName?: (params: {wellKnownName: string}) => string;
+  marksymbolizerParseFailedUnknownWellknownName?: (params: { wellKnownName: string }) => string;
   noFilterDetected?: string;
-  symbolizerKindParseFailed?: (params: {sldSymbolizerName: string}) => string;
+  symbolizerKindParseFailed?: (params: { sldSymbolizerName: string }) => string;
   colorMapEntriesParseFailedColorUndefined?: string;
   contrastEnhancParseFailedHistoAndNormalizeMutuallyExclusive?: string;
   channelSelectionParseFailedRGBAndGrayscaleMutuallyExclusive?: string;
@@ -151,10 +152,10 @@ export type SldStyleParserTranslations = Record<string, SldStyleParserTranslatio
 
 export const defaultTranslations: SldStyleParserTranslations = {
   en: {
-    marksymbolizerParseFailedUnknownWellknownName: ({wellKnownName}) =>
+    marksymbolizerParseFailedUnknownWellknownName: ({ wellKnownName }) =>
       `MarkSymbolizer cannot be parsed. WellKnownName ${wellKnownName} is not supported.`,
     noFilterDetected: 'No Filter detected.',
-    symbolizerKindParseFailed: ({sldSymbolizerName}) =>
+    symbolizerKindParseFailed: ({ sldSymbolizerName }) =>
       `Failed to parse SymbolizerKind ${sldSymbolizerName} from SldRule.`,
     colorMapEntriesParseFailedColorUndefined: 'Cannot parse ColorMapEntries. color is undefined.',
     contrastEnhancParseFailedHistoAndNormalizeMutuallyExclusive:
@@ -166,21 +167,21 @@ export const defaultTranslations: SldStyleParserTranslations = {
   },
   de: {},
   fr: {
-    marksymbolizerParseFailedUnknownWellknownName: ({wellKnownName}) =>
+    marksymbolizerParseFailedUnknownWellknownName: ({ wellKnownName }) =>
       `Échec de lecture du symbole de type MarkSymbolizer. Le WellKnownName ${wellKnownName} n'est pas supporté.`,
     noFilterDetected: 'Aucun filtre détecté.',
-    symbolizerKindParseFailed: ({sldSymbolizerName}) =>
+    symbolizerKindParseFailed: ({ sldSymbolizerName }) =>
       `Échec de lecture du type de symbole ${sldSymbolizerName} à partir de SldRule.`,
     colorMapEntriesParseFailedColorUndefined: 'Lecture de ColorMapEntries échoué. color n\'est pas défini.',
     contrastEnhancParseFailedHistoAndNormalizeMutuallyExclusive:
       'Échec de lecture des propriétés de contraste ContrastEnhancement échoué. '
-      +'Histogram et Normalize sont mutuellement exclusifs.',
+      + 'Histogram et Normalize sont mutuellement exclusifs.',
     channelSelectionParseFailedRGBAndGrayscaleMutuallyExclusive:
       'Échec de lecture de la sélection de canaux ChannelSelection. '
-      +'RGB et Grayscale sont mutuellement exclusifs.',
+      + 'RGB et Grayscale sont mutuellement exclusifs.',
     channelSelectionParseFailedRGBChannelsUndefined:
       'Échec de lecture de la sélection de canaux ChannelSelection. '
-      +'Les canaux Rouge, Vert et Bleu doivent être définis.',
+      + 'Les canaux Rouge, Vert et Bleu doivent être définis.',
 
   },
 } as const;
@@ -319,7 +320,7 @@ export class SldStyleParser implements StyleParser<string> {
       this.locale = opts.locale;
     }
 
-    if (opts?.translations){
+    if (opts?.translations) {
       this.translations = merge(this.translations, opts.translations);
     }
 
@@ -738,7 +739,7 @@ export class SldStyleParser implements StyleParser<string> {
 
     const comparisonOperator: ComparisonOperator = COMPARISON_MAP[sldOperatorName] as ComparisonOperator;
     const filterIsFunction = !!get(sldFilter, 'Function');
-    let args: (FunctionCall<unknown>|null)[] = [];
+    let args: (FunctionCall<unknown> | null)[] = [];
 
     const children = get(sldFilter, filterIsFunction ? 'Function' : sldOperatorName) || [];
     args = children.map((child: any, index: number) => {
@@ -815,6 +816,29 @@ export class SldStyleParser implements StyleParser<string> {
     } else {
       return get([child], '#text');
     }
+  }
+
+  /**
+   * Get offset from Displacement.
+   * In SLD positive y values mean a displacement to the top.
+   * In geostyler-style positive y values mean a displacement to the bottom.
+   * Thus the y value is inverted.
+   *
+   * @param displacement The SLD Displacement object as written by fast-xml-parser
+   * @returns The offset as tuple or undefined if displacement is undefined
+   */
+  getOffsetFromDisplacement(displacement: any): BasePointSymbolizer['offset'] | undefined {
+    if (isNil(displacement)) {
+      return;
+    };
+
+    const x = Number(get(displacement, 'DisplacementX.#text'));
+    const y = Number(get(displacement, 'DisplacementY.#text'));
+
+    return [
+      Number.isFinite(x) ? numberExpression(x) : 0,
+      Number.isFinite(y) && y !== 0 ? -numberExpression(y) : 0,
+    ];
   }
 
   /**
@@ -991,13 +1015,9 @@ export class SldStyleParser implements StyleParser<string> {
           textSymbolizer.anchor = this.getAnchorFromSldAnchorPoint(anchorX, anchorY);
         }
         const displacement = get(pointPlacement, 'Displacement');
-        if (!isNil(displacement)) {
-          const x = get(displacement, 'DisplacementX.#text');
-          const y = get(displacement, 'DisplacementY.#text');
-          textSymbolizer.offset = [
-            Number.isFinite(x) ? numberExpression(x) : 0,
-            Number.isFinite(y) ? -numberExpression(y) : 0,
-          ];
+        const offset = this.getOffsetFromDisplacement(displacement);
+        if (!isNil(offset)) {
+          textSymbolizer.offset = offset;
         }
         const rotation = get(pointPlacement, 'Rotation.#text');
         if (!isNil(rotation)) {
@@ -1165,7 +1185,7 @@ export class SldStyleParser implements StyleParser<string> {
     const graphicFill = get(sldFillSymbolizer, 'Fill.GraphicFill');
     if (!isNil(graphicFill)) {
       fillSymbolizer.graphicFill = this.getPointSymbolizerFromSldSymbolizer(
-        {PointSymbolizer: graphicFill}
+        { PointSymbolizer: graphicFill }
       );
     }
     if (this.isSldEnv(sldEnvGeoServer)) {
@@ -1292,13 +1312,9 @@ export class SldStyleParser implements StyleParser<string> {
     if (!isNil(distanceUnit)) {
       markSymbolizer.radiusUnit = distanceUnit;
     }
-    if (displacement) {
-      const x = get(displacement, 'DisplacementX.#text');
-      const y = get(displacement, 'DisplacementY.#text');
-      markSymbolizer.offset = [
-        Number.isFinite(x) ? numberExpression(x) : 0,
-        Number.isFinite(y) ? numberExpression(y) : 0,
-      ];
+    const offset = this.getOffsetFromDisplacement(displacement);
+    if (!isNil(offset)) {
+      markSymbolizer.offset = offset;
     }
 
     switch (wellKnownName) {
@@ -1436,13 +1452,9 @@ export class SldStyleParser implements StyleParser<string> {
     if (!isNil(rotation)) {
       iconSymbolizer.rotate = numberExpression(rotation);
     }
-    if (displacement) {
-      const x = get(displacement, 'DisplacementX.#text');
-      const y = get(displacement, 'DisplacementY.#text');
-      iconSymbolizer.offset = [
-        Number.isFinite(x) ? numberExpression(x) : 0,
-        Number.isFinite(y) ? numberExpression(y) : 0,
-      ];
+    const offset = this.getOffsetFromDisplacement(displacement);
+    if (!isNil(offset)) {
+      iconSymbolizer.offset = offset;
     }
     return iconSymbolizer;
   }
@@ -1912,13 +1924,13 @@ export class SldStyleParser implements StyleParser<string> {
    * an uom-attribute. Do it only for SLD 1.1.0, ignore it otherwise.
    */
   moveUomEntryToAttributes(sldSymbolizer: any, sldSymbolizerProperties: any[]) {
-    const uomValue = sldSymbolizerProperties[sldSymbolizerProperties.length-1].uom;
+    const uomValue = sldSymbolizerProperties[sldSymbolizerProperties.length - 1].uom;
     if (!uomValue) {
       return;
     }
     // put uom as attribute of symbolizer-node
     if (this.sldVersion === '1.1.0') {
-      sldSymbolizer[':@'] = {'@_uom': uomValue};
+      sldSymbolizer[':@'] = { '@_uom': uomValue };
     }
     // and remove this entry from symbolizer-properties because it isn't a valid property
     sldSymbolizerProperties.pop();
@@ -1931,10 +1943,10 @@ export class SldStyleParser implements StyleParser<string> {
    */
   addUomEntry(sldSymbolizerProperties: any[], unit: DistanceUnit | undefined) {
     if (unit === 'm') {
-      sldSymbolizerProperties.push({uom: unitSldMetre});
+      sldSymbolizerProperties.push({ uom: unitSldMetre });
     }
     if (unit === 'px') {
-      sldSymbolizerProperties.push({uom: unitSldPixel});
+      sldSymbolizerProperties.push({ uom: unitSldPixel });
     }
   }
 
@@ -1946,7 +1958,7 @@ export class SldStyleParser implements StyleParser<string> {
     if (!sldSymbolizer) {
       return undefined;
     }
-    const uomAttribute = getAttribute(sldSymbolizer,'uom');
+    const uomAttribute = getAttribute(sldSymbolizer, 'uom');
     if (!uomAttribute) {
       return undefined;
     }
@@ -2015,6 +2027,38 @@ export class SldStyleParser implements StyleParser<string> {
   }
 
   /**
+   * Get the SLD Displacement Object (readable with fast-xml-parser) from a geostyler-style offset.
+   * In SLD positive y values mean a displacement to the top.
+   * In geostyler-style positive y values mean a displacement to the bottom.
+   * Thus the y value is inverted.
+   *
+   * @param offset A geostyler-style offset as a tuple of two numbers or two functions.
+   * @returns The object representation of a SLD Displacement (readable with fast-xml-parser)
+   */
+  getDisplacementFromOffset(offset: [Expression<number>, Expression<number>]): any {
+    const Displacement = this.getTagName('Displacement');
+    const DisplacementX = this.getTagName('DisplacementX');
+    const DisplacementY = this.getTagName('DisplacementY');
+    const displacementX = isGeoStylerFunction(offset[0])
+      ? geoStylerFunctionToSldFunction(offset[0])
+      : [{
+        '#text': offset[0].toString()
+      }];
+    const displacementY = isGeoStylerFunction(offset[1])
+      ? geoStylerFunctionToSldFunction(offset[1])
+      : [{
+        '#text': (offset[1] * -1).toString()
+      }];
+    return {
+      [Displacement]: [{
+        [DisplacementX]: displacementX
+      }, {
+        [DisplacementY]: displacementY
+      }]
+    };
+  }
+
+  /**
    * Get the SLD Object (readable with fast-xml-parser) from a geostyler-style MarkSymbolizer.
    *
    * @param markSymbolizer A geostyler-style MarkSymbolizer.
@@ -2030,9 +2074,6 @@ export class SldStyleParser implements StyleParser<string> {
     const Rotation = this.getTagName('Rotation');
     const Size = this.getTagName('Size');
     const Graphic = this.getTagName('Graphic');
-    const Displacement = this.getTagName('Displacement');
-    const DisplacementX = this.getTagName('DisplacementX');
-    const DisplacementY = this.getTagName('DisplacementY');
 
     const isFontSymbol = WELLKNOWNNAME_TTF_REGEXP.test(markSymbolizer.wellKnownName);
     const mark: any[] = [{
@@ -2214,17 +2255,7 @@ export class SldStyleParser implements StyleParser<string> {
     }
 
     if (markSymbolizer.offset && (this.sldVersion === '1.1.0' || this.isSldEnv(sldEnvGeoServer))) {
-      graphic.push({
-        [Displacement]: [{
-          [DisplacementX]: [{
-            '#text': markSymbolizer.offset[0].toString()
-          }]
-        }, {
-          [DisplacementY]: [{
-            '#text': markSymbolizer.offset[1].toString()
-          }]
-        }]
-      });
+      graphic.push(this.getDisplacementFromOffset(markSymbolizer.offset));
     }
 
     const result = [{
@@ -2365,7 +2396,7 @@ export class SldStyleParser implements StyleParser<string> {
           '@_xmlns:xlink': 'http://www.w3.org/1999/xlink',
           '@_xlink:href': image,
         }
-      }, {[Format]: []}]
+      }, { [Format]: [] }]
     };
 
     const iconExt = image.split('.').pop();
@@ -2449,7 +2480,7 @@ export class SldStyleParser implements StyleParser<string> {
     const gsAnchorHoriz = anchorX < 0.25 ? 'left' : anchorX > 0.75 ? 'right' : '';
     const gsAnchorVert = anchorY < 0.25 ? 'bottom' : anchorY > 0.75 ? 'top' : '';
     const gsAnchor: TextSymbolizer['anchor'] = ((gsAnchorHoriz && gsAnchorVert) ?
-      (gsAnchorVert + '-' +gsAnchorHoriz) : (gsAnchorVert + gsAnchorHoriz)) as TextSymbolizer['anchor'];
+      (gsAnchorVert + '-' + gsAnchorHoriz) : (gsAnchorVert + gsAnchorHoriz)) as TextSymbolizer['anchor'];
 
     // for not breaking existing tests like "can read the geoserver popshade.sld", we treat
     // a center anchor as the default and deliver undefined in this case (instead of 'center')
@@ -2594,11 +2625,11 @@ export class SldStyleParser implements StyleParser<string> {
         pointPlacement.push({
           [AnchorPoint]: [{
             [AnchorPointX]: [{
-              '#text': this.getSldAnchorPointFromAnchor(textSymbolizer.anchor,'x').toString()
+              '#text': this.getSldAnchorPointFromAnchor(textSymbolizer.anchor, 'x').toString()
             }]
           }, {
             [AnchorPointY]: [{
-              '#text': this.getSldAnchorPointFromAnchor(textSymbolizer.anchor,'y').toString()
+              '#text': this.getSldAnchorPointFromAnchor(textSymbolizer.anchor, 'y').toString()
             }]
           }]
         });
@@ -2691,8 +2722,7 @@ export class SldStyleParser implements StyleParser<string> {
    * @param template The Expression<string> representing the label
    */
   getSldLabelFromTextSymbolizer = (template: Expression<string>): any => {
-    if (isString(template))
-    {
+    if (isString(template)) {
       const openingBraces = '{{';
       const closingBraces = '}}';
 
@@ -2797,15 +2827,15 @@ export class SldStyleParser implements StyleParser<string> {
     }
 
     if (typeof func === 'object') {
-    // Finding functions such as 'greaterThan', 'numberFormat', 'if_then_else' etc.
+      // Finding functions such as 'greaterThan', 'numberFormat', 'if_then_else' etc.
       if (typeof func.name === 'string' || Array.isArray(func.args)) {
         const sldArgs = func.args.map((arg: any) => {
           // Property function
           if (
             typeof arg === 'object' &&
-        arg !== null &&
-        arg.name === 'property' &&
-        Array.isArray(arg.args)
+            arg !== null &&
+            arg.name === 'property' &&
+            Array.isArray(arg.args)
           ) {
             return {
               'ogc:PropertyName': [
@@ -2816,9 +2846,9 @@ export class SldStyleParser implements StyleParser<string> {
           // Nested function
           if (
             typeof arg === 'object' &&
-        arg !== null &&
-        typeof arg.name === 'string' &&
-        Array.isArray(arg.args)
+            arg !== null &&
+            typeof arg.name === 'string' &&
+            Array.isArray(arg.args)
           ) {
             //  Another function such as 'greaterThan', 'numberFormat' in the above function such as 'if_then_else'
             return this.geoStylerFunctionToSldFunctionRecursive(arg)[0];
@@ -2842,7 +2872,7 @@ export class SldStyleParser implements StyleParser<string> {
       // Property function at root
       if (
         func.name === 'property' &&
-      Array.isArray(func.args)
+        Array.isArray(func.args)
       ) {
         return {
           'ogc:PropertyName': [
@@ -3306,11 +3336,11 @@ export class SldStyleParser implements StyleParser<string> {
           } else {
             Object.keys(symbolizer).forEach(property => {
               if (value[property]) {
-                // Escape special regex characters
-                const escapedValue = String(symbolizer[property as keyof typeof symbolizer]).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+                // Escape special regex characters in the symbolizer property value
+                const val = symbolizer[property as keyof typeof symbolizer];
+                const escapedValue = String(val).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
                 const propValue = new RegExp(`["']${escapedValue}["']`);
-                if (value[property].support === 'partial' && (propValue.test(value[property].info)))
-                {
+                if (value[property].support === 'partial' && (propValue.test(value[property].info))) {
                   return;
                 }
                 if (!unsupportedProperties.Symbolizer) {

--- a/src/SldStyleParser.v1.1.spec.ts
+++ b/src/SldStyleParser.v1.1.spec.ts
@@ -66,7 +66,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (reading
   let styleParser: SldStyleParser;
 
   beforeEach(() => {
-    styleParser = new SldStyleParser({sldVersion: '1.1.0'});
+    styleParser = new SldStyleParser({ sldVersion: '1.1.0' });
   });
 
   describe('#readStyle', () => {
@@ -75,121 +75,121 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (reading
     });
     it('can read a SLD 1.1 PointSymbolizer', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/point_simplepoint.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_simplepoint);
     });
     it('can read a SLD 1.1 PointSymbolizer with Displacment', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/point_simplepoint_displacement.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_simplepoint_displacement);
     });
     it('can read a SLD 1.1 PointSymbolizer with ExternalGraphic', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/point_externalgraphic.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_externalgraphic);
     });
     it('can read a SLD 1.1 PointSymbolizer with ExternalGraphic with floating-point values', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/point_externalgraphic_floatingPoint.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_externalgraphic_floatingPoint);
     });
     it('can read a SLD 1.1 PointSymbolizer with ExternalGraphic containing inlineContent', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/point_externalgraphic_inlineContent.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_externalgraphic_inlineContent);
     });
     it('can read a SLD 1.1 PointSymbolizer with ExternalGraphic svg', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/point_externalgraphic_svg.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_externalgraphic_svg);
     });
     it('can read a SLD 1.1 PointSymbolizer with ExternalGraphic and Displacement', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/point_externalgraphic_svg_displacement.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_externalgraphic_svg_displacement);
     });
     it('can read a SLD 1.1 PointSymbolizer with wellKnownName square', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/point_simplesquare.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_simplesquare);
     });
     it('can read a SLD 1.1 PointSymbolizer with wellKnownName triangle', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/point_simpletriangle.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_simpletriangle);
     });
     it('can read a SLD 1.1 PointSymbolizer with wellKnownName star', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/point_simplestar.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_simplestar);
     });
     it('can read a SLD 1.1 PointSymbolizer with wellKnownName cross', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/point_simplecross.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_simplecross);
     });
     it('can read a SLD 1.1 PointSymbolizer with wellKnownName x', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/point_simplex.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_simplex);
     });
     it('can read a SLD 1.1 PointSymbolizer with wellKnownName shape://slash', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/point_simpleslash.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_simpleslash);
     });
     it('can read a SLD 1.1 PointSymbolizer with wellKnownName using a font glyph (starting with ttf://)', async () => {
-      const sld = fs.readFileSync( './data/slds/1.1/point_fontglyph.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const sld = fs.readFileSync('./data/slds/1.1/point_fontglyph.sld', 'utf8');
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_fontglyph);
     });
     it('can read a SLD 1.1 LineSymbolizer', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/line_simpleline.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(line_simpleline);
     });
     it('can read a SLD 1.1 LineSymbolizer with Perpendicular Offset', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/line_perpendicularOffset.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(line_perpendicularOffset);
     });
     it('can read a SLD 1.1 LineSymbolizer with GraphicStroke', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/line_graphicStroke.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(line_graphicStroke);
     });
     it('can read a SLD 1.1 LineSymbolizer with GraphicStroke and ExternalGraphic', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/line_graphicStroke_externalGraphic.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(line_graphicStroke_externalGraphic);
     });
     it('can read a SLD 1.1 LineSymbolizer with GraphicFill', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/line_graphicFill.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(line_graphicFill);
     });
     it('can read a SLD 1.1 LineSymbolizer with Unit-Of-Measure in Pixels', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/line_pixelWidth.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle?.rules.length).toBe(1);
       expect(geoStylerStyle?.rules[0].symbolizers.length).toBe(1);
@@ -199,7 +199,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (reading
     });
     it('can read a SLD 1.1 LineSymbolizer with Unit-Of-Measure in Ground-Units', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/line_groundUnitWidth.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle?.rules.length).toBe(1);
       expect(geoStylerStyle?.rules[0].symbolizers.length).toBe(1);
@@ -209,115 +209,115 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (reading
     });
     it('can read a SLD 1.1 LineSymbolizer with GraphicFill and ExternalGraphic', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/line_graphicFill_externalGraphic.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(line_graphicFill_externalGraphic);
     });
     it('can read a SLD 1.1 PolygonSymbolizer', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/polygon_transparentpolygon.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(polygon_transparentpolygon);
     });
     it('can read a SLD 1.1 PolygonSymbolizer with GraphicFill', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/polygon_graphicFill.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(polygon_graphicFill);
     });
     it('can read a SLD 1.1 PolygonSymbolizer with GraphicFill and ExternalGraphic', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/polygon_graphicFill_externalGraphic.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(polygon_graphicFill_externalGraphic);
     });
     it('can read a SLD 1.1 TextSymbolizer', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/point_styledlabel.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_styledlabel);
     });
     it('can read a SLD 1.1 TextSymbolizer with a static label', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/point_simpleLabel.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_simpleLabel);
     });
     it('can read a SLD 1.1 TextSymbolizer with a static label and styling', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/point_simpleLabel2.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_simpleLabel2);
     });
     it('can read a SLD 1.1 TextSymbolizer with a static label and point placement', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/text_pointplacement.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(text_pointplacement);
     });
     it('can read a SLD 1.1 TextSymbolizer with a static label with point placement and anchor', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/text_pointplacement_anchor.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(text_pointplacement_with_anchor);
     });
     it('can read a SLD 1.1 TextSymbolizer with a static label and line placement', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/text_lineplacement.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(text_lineplacement);
     });
     it('can read a SLD 1.1 TextSymbolizer with a static label, line placement and perpendicular offset', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/text_lineplacement.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(text_lineplacement);
     });
     it('can read a SLD 1.1 TextSymbolizer with a static label, line placement and repeat', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/text_lineplacement_repeat.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(text_lineplacement_repeat);
     });
     it('can read a simple SLD 1.1 RasterSymbolizer', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/raster_simpleRaster.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(raster_simpleraster);
     });
     it('can read a complex SLD 1.1 RasterSymbolizer', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/raster_complexRaster.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(raster_complexraster);
     });
     it('can read a SLD 1.1 style with a filter', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/point_simplepoint_filter.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_simplepoint_filter);
     });
     it('can read a SLD 1.1 style with nested logical filters', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/point_simplepoint_nestedLogicalFilters.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_simplepoint_nestedLogicalFilters);
     });
     it('can read a SLD 1.1 style with multiple symbolizers in one Rule', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/multi_simplelineLabel.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(multi_simplelineLabel);
     });
     it('can read a SLD 1.1 style with a styled label containing a PropertyName and a Literal', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/point_styledLabel_literalPlaceholder.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_styledLabel_literalPlaceholder);
     });
     it('can read a SLD style with a styled label and preserve its order', async () => {
       const sld = fs.readFileSync('./data/slds/1.1/point_styledLabel_elementOrder.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_styledLabel_elementOrder);
     });
@@ -442,7 +442,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
   let styleParser: SldStyleParser;
 
   beforeEach(() => {
-    styleParser = new SldStyleParser({sldVersion: '1.1.0'});
+    styleParser = new SldStyleParser({ sldVersion: '1.1.0' });
   });
 
   describe('#writeStyle', () => {
@@ -455,7 +455,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_simplepoint);
     });
     it('can write a SLD 1.1 PointSymbolizer with Displacement', async () => {
@@ -463,7 +463,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_simplepoint_displacement);
     });
     it('can write a SLD 1.1 PointSymbolizer with ExternalGraphic', async () => {
@@ -471,7 +471,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_externalgraphic);
     });
     it('can write a SLD 1.1 PointSymbolizer with ExternalGraphic containing InlineContent', async () => {
@@ -479,7 +479,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_externalgraphic_inlineContent);
     });
     it('can write a SLD 1.1 PointSymbolizer with ExternalGraphic svg', async () => {
@@ -487,7 +487,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_externalgraphic_svg);
     });
     it('can write a SLD 1.1 PointSymbolizer with ExternalGraphic svg and displacment', async () => {
@@ -495,7 +495,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_externalgraphic_svg_displacement);
     });
     it('can write a SLD 1.1 PointSymbolizer with wellKnownName square', async () => {
@@ -503,7 +503,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_simplesquare);
     });
     it('can write a SLD 1.1 PointSymbolizer with wellKnownName triangle', async () => {
@@ -511,7 +511,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_simpletriangle);
     });
     it('can write a SLD 1.1 PointSymbolizer with wellKnownName star', async () => {
@@ -519,7 +519,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_simplestar);
     });
     it('can write a SLD 1.1 PointSymbolizer with wellKnownName cross', async () => {
@@ -527,7 +527,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_simplecross);
     });
     it('can write a SLD 1.1 PointSymbolizer with wellKnownName x', async () => {
@@ -535,7 +535,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_simplex);
     });
     it('can write a SLD 1.1 PointSymbolizer with wellKnownName shape://slash', async () => {
@@ -543,7 +543,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_simpleslash);
     });
     it('can write a SLD 1.1 PointSymbolizer with wellKnownName using a font glyph (starting with ttf://)', async () => {
@@ -551,7 +551,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_fontglyph);
     });
     it('can write a SLD 1.1 LineSymbolizer', async () => {
@@ -559,7 +559,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(line_simpleline);
     });
     it('can write a SLD 1.1 LineSymbolizer with PerpendicularOffset', async () => {
@@ -567,7 +567,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(line_perpendicularOffset);
     });
     it('can write a SLD 1.1 LineSymbolizer with GraphicStroke', async () => {
@@ -575,7 +575,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(line_graphicStroke);
     });
     it('can write a SLD 1.1 LineSymbolizer with GraphicStroke and ExternalGraphic', async () => {
@@ -583,7 +583,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(line_graphicStroke_externalGraphic);
     });
     it('can write a SLD 1.1 LineSymbolizer with GraphicFill', async () => {
@@ -591,7 +591,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(line_graphicFill);
     });
     it('can write a SLD 1.1 LineSymbolizer with GraphicFill and ExternalGraphic', async () => {
@@ -599,7 +599,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(line_graphicFill_externalGraphic);
     });
     it('can write a SLD 1.1 LineSymbolizer with Unit-Of-Measure in Ground-Units', async () => {
@@ -607,7 +607,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(line_groundUnitWidth);
     });
     it('can write a SLD 1.1 PolygonSymbolizer', async () => {
@@ -615,7 +615,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(polygon_transparentpolygon);
     });
     it('can write a SLD 1.1 PolygonSymbolizer with GraphicFill', async () => {
@@ -623,7 +623,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(polygon_graphicFill);
 
       const sld = fs.readFileSync('./data/slds/1.1/polygon_graphicFill.sld', 'utf8');
@@ -635,7 +635,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(polygon_graphicFill_externalGraphic);
     });
     it('can write a SLD 1.1 TextSymbolizer', async () => {
@@ -643,7 +643,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_styledlabel);
     });
     it('can write a SLD 1.1 TextSymbolizer with point placement', async () => {
@@ -651,7 +651,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(text_pointplacement);
     });
     it('can write a SLD 1.1 TextSymbolizer with point placement and anchor', async () => {
@@ -659,7 +659,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(text_pointplacement_with_anchor);
     });
     it('can write a SLD 1.1 TextSymbolizer with line placement', async () => {
@@ -667,23 +667,23 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(text_lineplacement);
     });
-    it('can write a SLD 1.1 TextSymbolizer with line placement and offset', async() =>{
-      const {output: sldString} = await styleParser.writeStyle(text_lineplacement_offset);
+    it('can write a SLD 1.1 TextSymbolizer with line placement and offset', async () => {
+      const { output: sldString } = await styleParser.writeStyle(text_lineplacement_offset);
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle?.rules[0].symbolizers).toEqual(text_lineplacement_offset.rules[0].symbolizers);
     });
-    it('can write a SLD 1.1 TextSymbolizer with line placement and repeat', async() =>{
-      const {output: sldString} = await styleParser.writeStyle(text_lineplacement_repeat);
+    it('can write a SLD 1.1 TextSymbolizer with line placement and repeat', async () => {
+      const { output: sldString } = await styleParser.writeStyle(text_lineplacement_repeat);
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle?.rules[0].symbolizers).toEqual(text_lineplacement_repeat.rules[0].symbolizers);
     });
     it('can write a simple SLD RasterSymbolizer', async () => {
@@ -691,7 +691,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(raster_simpleraster);
     });
     it('can write a complex SLD RasterSymbolizer', async () => {
@@ -699,7 +699,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(raster_complexraster);
     });
     it('can write a SLD 1.1 style with a filter', async () => {
@@ -707,7 +707,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_simplepoint_filter);
     });
     it('can write a SLD 1.1 style with a filter and force cast of numeric fields', async () => {
@@ -717,7 +717,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_simplepoint_filter_forceNumerics);
     });
     it('can write a SLD 1.1 style with a filter and force cast of numeric fields (forceCasting)', async () => {
@@ -725,7 +725,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_simplepoint_filter_forceNumerics);
     });
     it('can write a SLD 1.1 style with a filter and force cast of boolean fields', async () => {
@@ -735,7 +735,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_simplepoint_filter_forceBools);
     });
     it('can write a SLD 1.1 style with a filter and force cast of boolean fields (forceCasting)', async () => {
@@ -744,7 +744,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_simplepoint_filter_forceBools);
     });
     it('can write a SLD 1.1 style with nested logical filters', async () => {
@@ -752,7 +752,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_simplepoint_nestedLogicalFilters);
     });
     it('can write a SLD 1.1 with nested property-to-property comparison filters', async () => {
@@ -786,7 +786,7 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_styledLabel_literalOpenCurlyBraces);
     });
     it('can write a SLD 1.1 style with a styled label containing placeholders and static text', async () => {
@@ -794,14 +794,14 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       expect(sldString).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_styledLabel_literalPlaceholder);
     });
     it('can write a SLD 1.1 style with a styled label containing newline expression', async () => {
       // This test validates that the writeStyle() method correctly converts a GeoStyler Style
       // with a newline character in a label (e.g., "{{fokr}}\n{{fokrname}}") into a properly
       // formatted SLD XML with a CDATA section containing the newline.
-      // 
+      //
       // We use a parser with format: true to ensure consistent XML formatting with proper
       // indentation and line breaks, matching the expected SLD file format.
       const styleParserWithFormat = new SldStyleParser({
@@ -813,9 +813,9 @@ describe('SldStyleParser with Symbology Encoding implements StyleParser (writing
       const expectedSld = fs.readFileSync('./data/slds/1.1/text_newLine_expression.sld', 'utf8');
       const expectedStyle = text_newLine_expression;
       const { output: generatedSld } = await styleParserWithFormat.writeStyle(expectedStyle);
-      
+
       // We only compare the generated SLD string with the expected SLD string (not JSON objects)
-      // because this is a write test verifying the XML output is correct. 
+      // because this is a write test verifying the XML output is correct.
       // We use trim() to remove any trailing whitespace from the file content that might cause
       // false negatives in the comparison due to editor settings or file system differences.
       expect(generatedSld).toBeDefined();


### PR DESCRIPTION
Update the displacement-offset conversion logic to ensure correct values are used by introducing new conversion functions. Be aware that this also fixes a sign error that seems to be in the parser for a long time. As the y value of SLD-displacment and geostyler-style-offset have opposite meanings.

Additionally, update the `geostyler-style` dependency version and perform some linting improvements.

This fixes #1074