### PR TITLE
Add test for base64 image handling

### DIFF
--- a/data/styles/point_base64_image.ts
+++ b/data/styles/point_base64_image.ts
@@ -1,0 +1,34 @@
+import { Style } from 'geostyler-style';
+
+const pointExternalGraphic: Style = {
+  name: '',
+  rules: [
+    {
+      name: 'Entrance Only',
+      filter: ['==', 'sign_legend', 'Entrance Only'],
+      symbolizers: [
+        {
+          kind: 'Icon',
+          image: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABcAAAAgCAYAAAD5VeO1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAC4ElEQVRIibXWTUgUYRzH8a86Yl4kzVmZIio7JLst7YxeRdQkctysS0Edc7tYh+gioVLbIt6CdDVIPAp1EDRXiF4siIrIHWjbqJM3H5cxKMQtc9vtkLu9ObOzoL/jM/N8/s/zzJ+ZkdjGSNuOm6a5u7Kysn7LUEm6n8OFEMquqqrprcIzmUxDUVHRfN5jMU0TWZZ5MTXNgdpaalwuimtcjorY4qZpsvTkKTsePKbu0RwAnwHJ66H0aAsr507jclkXssW/P3zCnp5+1v8ZT8XipGJxymPviF+5hMfjKQxPzD2j7Oo1u9qsP5qj1nsYCsHj8TgHXr3mWzptiwMkb43wpuEIjY2NznBZlkk9f0nZ2dN58bWJe1QYb8EpXlJSwvf3H9g5GETybr7lbH7E4lRJm5/upqPpdJrS6l18vTmcFweQDtY6x2VZZrW1mbWJu6xvtKBVimtcKMfanOMA5ZcvsjZx1xYGKG1tZnl5merqauf4p+IiKgaDrPb0W8LFLU0kr1xC3gS2xWVZhrNnKPEeJtnTRyoW/z3J6+HL8TZWWppwy7Jl8bzvFsnroSIySeLDR1KJBABlHjd7LVZbEJ5NTd0hqDvk9Pb8+PVgELG4iN/vByBqGKiqihACwzAA6OvtRVGUwvH5+Xmmp6YA2Ld/P7quo/p8kMmgqSqAJZwXz67+QiCAoig50GlscSEE9ZqGEAJN07gRChEeHt4a/PboKEII4NfZdp0/D0B9vbPPrSUejUYxDANd13MF/kx2N5HZWfT29sLwO2Nj+Hw+Tp46ha7rKIpCZGaGDr8fZWkJgFAoRDQaLRwXQjA0NMT4+DgAkZmZv67r7e10d3cTDoetiPwPNNtqekcHwWCQjo2eB9BU1baDLPH+vj4GBgYIdHXlCgQCATRVJRQKMRuJoGma3dqscU3TGB0Z+W8MYHJy0hb9C19YWBBut/uEoxkOspZMihze2dm5CCxuFZ7Ntv7l/gQYGvFshJBPEwAAAABJRU5ErkJggg==',
+          size: 17,
+          format: 'image/png',
+        },
+      ],
+    },
+    {
+      name: 'Number',
+      filter: ['==', 'sign_legend', 'Number'],
+      symbolizers: [
+        {
+          kind: 'Icon',
+          // the problem seems to be this base64
+          image: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAAQCAYAAABKkhw/AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAESklEQVRIieWWzU8VVxiHn/fMvcy9fCtBip8VRNKmKJHUpqkfERc1YVEbEyOJG1e60fix8C9QVhKDCcsSogZWrjBtwk0wwXZRQqotNCm1xqpg9QL3ckHmztyZc7pQqHBRrlGbmv5W7/zed855nzNnZk6I/5lCS5k9PT1fbti44StADEa00aJQGQxaixaF8pRStjZaY1CiZDbQQX7YCucHOvAMZlqhBDBAmSAZI8YPgsAXJV5IhbwgCCyDKRPEFZEgMIFliRUVJRGllGitJdDBY9GiDCZkKcsKCAIMYaWUbbRJIbgGo8OhcDWgBHEymczYVGJqeOfOnd/kBHzx4sUKU2V6dv+4OzTpTr7Nxf1XFA1FaalvyQC5AVdVVW3sT/W/l7AAju8QexILvyyfBZxOpzMG8267escyGIwxAiAiC2CWfIcXS0SoW1nH0OQQ2uhX1hbnFZPyUghCTUkNI1Mjr93wCnsFCTfx1mthCeBwOGwt9g5WHeToR0fpHe2l5aeWVw7YuLqRvrE+NpdspmtvF5u6N+XczJz2f7ifjt86cqq90niFpm+bsvzFT3ZOWcDJZDJF5UIvNhrj3KfnmEhPUBYp49IXlxh3xrk1cYu703c5veU0zbFmnvpPAbjaeJV1hesIqzCHaw5TmV/J2fqzrOpcxdrCtVz4/ALtw+0kvSS1JbU0lDcQUiGGJ4fZVbmLvrG+nGDPbDlDbUktJz45QdtQ24Jczlu6uLi4aLGX9tM0fddEx+4OCsOFzPqzFIQLAHg48xBf+1jqn41RU1JDbDTGjg92cLLuJJ0jnRhjQOD+zH0ezT7CtuwFc+xZvYfq4mpuj9/OCRagbmUdDdcaGPh6gK47XcTT8WXvyQKORqN5iz1Xu+xdvZcDvQeYcCdorm5mZGqEuBPnsfOYtqE2HN8BYHB8kG3XtuEGLvvW7uPezD22l2/n+A/H59//y79fZvTpKIeqDjHpTtL9Rzf9j/opi5TR/Uc3a/LX5AR85MYRTm05RWNPYxZszlva9/0gy9M+7b+2z193jnQuyN8YuzEfP5h5MB/33O8BYGhyaEH9wJMBAFp/aZ33Bhmcj++k7izVa5YMhtafW5cvfEFZwJ7n+a81wnumLOB4PD5e/3E9StSyv6D/ogRha+lWrnN9yXwW8LFjx/68+f3Na72f9e5PuAllMCA8OzMjwLOttCBWksGgjDHWnC+WeEabMAZ5sR55fqoxc8YbyxjMs1EVOqqiusQtiZ3nfG7AImKMMQeBsunpaT0zMzOrlJKKiopKwPY8z+Tl5XmABnAcJxONRscAC1ifTqf9SCSSAlLAetd1xbZtcRzH0Vr7BQUFs8lk0iotLY0unjuRSMzm5+eX27ZtA7ium/Y8b6qoqMgAec/7DdLpdF4kEom6ruvatv0XoOLxOOXl5T6gRcR72eosedISkQB4sshe7ksSLFFz9xX1yZf4U8vM80b6GyCb2xhrhxymAAAAAElFTkSuQmCC',
+          size: 45,
+          format: 'image/png',
+        },
+      ],
+    },
+  ]
+};
+
+export default pointExternalGraphic;

--- a/src/SldStyleParser.v1.0.spec.ts
+++ b/src/SldStyleParser.v1.0.spec.ts
@@ -23,6 +23,7 @@ import point_simplepoint_filter from '../data/styles/point_simplepoint_filter';
 import point_simplepoint_filter_forceBools from '../data/styles/point_simplepoint_filter_forceBools';
 import point_simplepoint_filter_forceNumerics from '../data/styles/point_simplepoint_filter_forceNumerics';
 import point_simplepoint_nestedLogicalFilters from '../data/styles/point_simplepoint_nestedLogicalFilters';
+import point_base64_image from '../data/styles/point_base64_image';
 import point_externalgraphic from '../data/styles/point_externalgraphic';
 import point_externalgraphic_floatingPoint from '../data/styles/point_externalgraphic_floatingPoint';
 import point_externalgraphic_svg from '../data/styles/point_externalgraphic_svg';
@@ -50,7 +51,7 @@ import functionFilterPropertyToProperty from '../data/styles/function_filter_pro
 import functionFilterOgcArithmetic from '../data/styles/function_filter_ogc_arithmetic';
 import functionLabelRound from '../data/styles/function_label_round';
 import point_externalgraphic_inlineContent from '../data/styles/point_externalgraphic_inlineContent';
-import {IconSymbolizer} from 'geostyler-style';
+import { IconSymbolizer } from 'geostyler-style';
 
 it('SldStyleParser is defined', () => {
   expect(SldStyleParser).toBeDefined();
@@ -60,7 +61,7 @@ describe('SldStyleParser implements StyleParser (reading)', () => {
   let styleParser: SldStyleParser;
 
   beforeEach(() => {
-    styleParser = new SldStyleParser({sldVersion: '1.0.0'});
+    styleParser = new SldStyleParser({ sldVersion: '1.0.0' });
   });
 
   describe('#readStyle', () => {
@@ -465,6 +466,13 @@ describe('SldStyleParser implements StyleParser (writing)', () => {
       const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_simplepoint);
     });
+    it('can write a SLD PointSymbolizer with base64 image', async () => {
+      const {
+        output: sldString
+      } = await styleParser.writeStyle(point_base64_image);
+      expect(sldString).toBeDefined();
+    });
+
     it('can write a SLD PointSymbolizer with ExternalGraphic', async () => {
       const {
         output: sldString,
@@ -496,7 +504,7 @@ describe('SldStyleParser implements StyleParser (writing)', () => {
       // we read it again and compare the json input with the parser output
       const { output: readStyle } = await styleParser.readStyle(sldString!);
       // Check the image is not included in the output.
-      const symbolizer = readStyle?.rules[0]?.symbolizers[0] as IconSymbolizer|undefined;
+      const symbolizer = readStyle?.rules[0]?.symbolizers[0] as IconSymbolizer | undefined;
       expect(symbolizer).toBeDefined();
       expect(symbolizer?.image).toBeUndefined();
     });
@@ -852,7 +860,7 @@ describe('SldStyleParser implements StyleParser (writing)', () => {
       expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_simplepoint_filter_forceNumerics);
     });
     it('can write a SLD style with a filter and force cast of numeric fields (forceCasting)', async () => {
@@ -868,7 +876,7 @@ describe('SldStyleParser implements StyleParser (writing)', () => {
       expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_simplepoint_filter_forceNumerics);
     });
     it('can write a SLD style with a filter and force cast of boolean fields', async () => {
@@ -886,7 +894,7 @@ describe('SldStyleParser implements StyleParser (writing)', () => {
       expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_simplepoint_filter_forceBools);
     });
     it('can write a SLD style with a filter and force cast of boolean fields (forceCasting)', async () => {
@@ -903,7 +911,7 @@ describe('SldStyleParser implements StyleParser (writing)', () => {
       expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_simplepoint_filter_forceBools);
     });
     it('can write a SLD style with nested logical filters', async () => {
@@ -976,7 +984,7 @@ describe('SldStyleParser implements StyleParser (writing)', () => {
       expect(errors).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_styledLabel_literalOpenCurlyBraces);
     });
     it('can write a SLD style with a styled label containing placeholders and static text', async () => {
@@ -1065,7 +1073,7 @@ describe('SldStyleParser implements StyleParser (writing)', () => {
           format: true
         }
       });
-      const { output: sldString} = await styleParserOrder.writeStyle(point_styledLabel_elementOrder);
+      const { output: sldString } = await styleParserOrder.writeStyle(point_styledLabel_elementOrder);
       expect(sldString).toBeDefined();
       const sld = fs.readFileSync('./data/slds/1.0/point_styledLabel_elementOrder.sld', 'utf8');
       expect(sldString).toEqual(sld.trim());


### PR DESCRIPTION
Introduce a test to verify the functionality of SLD PointSymbolizer with base64 images, ensuring proper handling and output.