### PR TITLE
Use Vite for build and replace Lodash with native JS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "fast-xml-parser": "^5.2.3",
-        "geostyler-style": "^11.0.2",
-        "lodash": "^4.17.21"
+        "geostyler-style": "^11.0.2"
       },
       "devDependencies": {
         "@commitlint/cli": "^20.3.1",
@@ -20,7 +19,6 @@
         "@semantic-release/git": "^10.0.1",
         "@stylistic/eslint-plugin": "^4.4.1",
         "@terrestris/eslint-config-typescript": "^9.0.0",
-        "@types/lodash": "^4.17.17",
         "@types/node": "^24.0.0",
         "@typescript-eslint/eslint-plugin": "^8.33.1",
         "@typescript-eslint/parser": "^8.33.1",
@@ -1308,6 +1306,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -2548,19 +2547,13 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-RDvF6wTulMPjrNdCoYRC8gNR880JNGT8uB+REUpC2Ns4pRqQJhGz90wh7rgdXDPpCczF3VGktDuFGVnz8zP7HA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/node": {
       "version": "24.10.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.13.tgz",
       "integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2578,6 +2571,7 @@
       "integrity": "sha512-lRyPDLzNCuae71A3t9NEINBiTn7swyOhvUj3MyUOxb8x6g6vPEFoOU+ZRmGMusNC3X3YMhqMIX7i8ShqhT74Pw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.56.0",
@@ -2607,6 +2601,7 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -2960,6 +2955,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3656,6 +3652,7 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -4200,6 +4197,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5881,6 +5879,7 @@
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash-es": {
@@ -6049,6 +6048,7 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -8283,6 +8283,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9217,6 +9218,7 @@
       "integrity": "sha512-6qGjWccl5yoyugHt3jTgztJ9Y0JVzyH8/Voc/D8PlLat9pwxQYXz7W1Dpnq5h0/G5GCYGUaDSlYcyk3AMh5A6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -10316,6 +10318,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10470,6 +10473,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10642,6 +10646,7 @@
       "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -10758,6 +10763,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10771,6 +10777,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   },
   "homepage": "https://github.com/geostyler/geostyler-sld-parser#readme",
   "scripts": {
-    "build-browser": "vite build",
-    "build-dist": "tsc -p tsconfig.build.json",
+    "build-browser": "vite build --config vite.config.browser.ts ",
+    "build-dist": "vite build --config vite.config.dist.ts && tsc -p tsconfig.build.json --emitDeclarationOnly",
     "build": "npm run build-browser && npm run build-dist",
     "lint:test:build": "npm run lint && npm run test && npm run build",
     "lint:test": "npm run lint && npm run test",
@@ -36,8 +36,7 @@
   },
   "dependencies": {
     "fast-xml-parser": "^5.2.3",
-    "geostyler-style": "^11.0.2",
-    "lodash": "^4.17.21"
+    "geostyler-style": "^11.0.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.3.1",
@@ -46,7 +45,6 @@
     "@semantic-release/git": "^10.0.1",
     "@stylistic/eslint-plugin": "^4.4.1",
     "@terrestris/eslint-config-typescript": "^9.0.0",
-    "@types/lodash": "^4.17.17",
     "@types/node": "^24.0.0",
     "@typescript-eslint/eslint-plugin": "^8.33.1",
     "@typescript-eslint/parser": "^8.33.1",

--- a/src/SldStyleParser.geoserver.spec.ts
+++ b/src/SldStyleParser.geoserver.spec.ts
@@ -1,7 +1,7 @@
 /* eslint camelcase: 0 */
 import fs from 'fs';
-import SldStyleParser, {sldEnvGeoServer} from './SldStyleParser';
-import {beforeEach, describe, expect, it} from 'vitest';
+import SldStyleParser, { sldEnvGeoServer } from './SldStyleParser';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import burg from '../data/styles/geoserver/burg';
 import capitals from '../data/styles/geoserver/capitals';
@@ -36,97 +36,97 @@ describe('SldStyleParser implements StyleParser', () => {
   let styleParser: SldStyleParser;
 
   beforeEach(() => {
-    styleParser = new SldStyleParser({sldEnvironment: sldEnvGeoServer});
+    styleParser = new SldStyleParser({ sldEnvironment: sldEnvGeoServer });
   });
 
   describe('#readStyle', () => {
     it('can read the geoserver burg.sld', async () => {
       const sld = fs.readFileSync('./data/slds/geoserver/burg.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(burg);
     });
     it('can read the geoserver captials.sld', async () => {
       const sld = fs.readFileSync('./data/slds/geoserver/capitals.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(capitals);
     });
     it('can read the geoserver default_generic.sld', async () => {
       const sld = fs.readFileSync('./data/slds/geoserver/default_generic.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(default_generic);
     });
     it('can read the geoserver default_line.sld', async () => {
       const sld = fs.readFileSync('./data/slds/geoserver/default_line.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(default_line);
     });
     it('can read the geoserver default_line2.sld', async () => {
       const sld = fs.readFileSync('./data/slds/geoserver/default_line2.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(default_line2);
     });
     it('can read the geoserver default_point.sld', async () => {
       const sld = fs.readFileSync('./data/slds/geoserver/default_point.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(default_point);
     });
     it('can read the geoserver default_polygon.sld', async () => {
       const sld = fs.readFileSync('./data/slds/geoserver/default_polygon.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(default_polygon);
     });
     it('can read the geoserver dem.sld', async () => {
       const sld = fs.readFileSync('./data/slds/geoserver/dem.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(dem);
     });
     it('can read the geoserver giant_polygon.sld', async () => {
       const sld = fs.readFileSync('./data/slds/geoserver/giant_polygon.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(giant_polygon);
     });
     it('can read the geoserver grass_poly.sld', async () => {
       const sld = fs.readFileSync('./data/slds/geoserver/grass_poly.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(grass_poly);
     });
     it('can read the geoserver green.sld', async () => {
       const sld = fs.readFileSync('./data/slds/geoserver/green.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(green);
     });
     it('can read the geoserver Lakes.sld', async () => {
       const sld = fs.readFileSync('./data/slds/geoserver/Lakes.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(Lakes);
     });
     it('can read the geoserver NamedPlaces.sld', async () => {
       const sld = fs.readFileSync('./data/slds/geoserver/NamedPlaces.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(NamedPlaces);
     });
     it('can read the geoserver poi.sld', async () => {
       const sld = fs.readFileSync('./data/slds/geoserver/poi.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(poi);
     });
     it('can read the geoserver poly_landmarks.sld', async () => {
       const sld = fs.readFileSync('./data/slds/geoserver/poly_landmarks.sld', 'utf8');
-      const { output: geoStylerStyle} = await styleParser.readStyle(sld);
+      const { output: geoStylerStyle } = await styleParser.readStyle(sld);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(poly_landmarks);
     });
@@ -204,7 +204,7 @@ describe('SldStyleParser implements StyleParser', () => {
       expect(unsupportedProperties).toBeDefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(burg);
     });
     it('can write the geoserver capitals.sld', async () => {
@@ -220,7 +220,7 @@ describe('SldStyleParser implements StyleParser', () => {
       expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(capitals);
     });
     // The SLD makes use of functions that are not supported by the geostyler-style
@@ -255,7 +255,7 @@ describe('SldStyleParser implements StyleParser', () => {
       expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(default_line);
     });
     it('can write the geoserver default_line2.sld', async () => {
@@ -271,7 +271,7 @@ describe('SldStyleParser implements StyleParser', () => {
       expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(default_line2);
     });
     it('can write the geoserver default_point.sld', async () => {
@@ -287,7 +287,7 @@ describe('SldStyleParser implements StyleParser', () => {
       expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(default_point);
     });
     it('can write the geoserver default_polygon.sld', async () => {
@@ -303,7 +303,7 @@ describe('SldStyleParser implements StyleParser', () => {
       expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(default_polygon);
     });
     it('can write the geoserver dem.sld', async () => {
@@ -319,7 +319,7 @@ describe('SldStyleParser implements StyleParser', () => {
       expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(dem);
     });
     it('can write the geoserver giant_polygon.sld', async () => {
@@ -335,7 +335,7 @@ describe('SldStyleParser implements StyleParser', () => {
       expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(giant_polygon);
     });
     it('can write the geoserver grass_poly.sld', async () => {
@@ -351,7 +351,7 @@ describe('SldStyleParser implements StyleParser', () => {
       expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(grass_poly);
     });
     it('can write the geoserver green.sld', async () => {
@@ -367,7 +367,7 @@ describe('SldStyleParser implements StyleParser', () => {
       expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(green);
     });
     it('can write the geoserver Lakes.sld', async () => {
@@ -383,7 +383,7 @@ describe('SldStyleParser implements StyleParser', () => {
       expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(Lakes);
     });
     it('can write the geoserver NamedPlaces.sld', async () => {
@@ -399,7 +399,7 @@ describe('SldStyleParser implements StyleParser', () => {
       expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(NamedPlaces);
     });
     it('can write the geoserver poi.sld', async () => {
@@ -411,7 +411,7 @@ describe('SldStyleParser implements StyleParser', () => {
       expect(errors).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(poi);
     });
     it('can write the geoserver poly_landmarks.sld', async () => {
@@ -423,7 +423,7 @@ describe('SldStyleParser implements StyleParser', () => {
       expect(errors).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(poly_landmarks);
     });
     it('can write the geoserver pophatch.sld', async () => {
@@ -435,7 +435,7 @@ describe('SldStyleParser implements StyleParser', () => {
       expect(errors).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(pophatch);
     });
     it('can write the geoserver popshade.sld', async () => {
@@ -447,7 +447,7 @@ describe('SldStyleParser implements StyleParser', () => {
       expect(errors).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(popshade);
     });
     it('can write the geoserver rain.sld', async () => {
@@ -463,7 +463,7 @@ describe('SldStyleParser implements StyleParser', () => {
       expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(rain);
     });
     it('can write the geoserver raster.sld', async () => {
@@ -479,7 +479,7 @@ describe('SldStyleParser implements StyleParser', () => {
       expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(raster);
     });
     it('can write the geoserver restricted.sld', async () => {
@@ -495,7 +495,7 @@ describe('SldStyleParser implements StyleParser', () => {
       expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(restricted);
     });
     it('can write the geoserver simple_streams.sld', async () => {
@@ -511,7 +511,7 @@ describe('SldStyleParser implements StyleParser', () => {
       expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(simple_streams);
     });
     it('can write the geoserver simpleRoads.sld', async () => {
@@ -527,7 +527,7 @@ describe('SldStyleParser implements StyleParser', () => {
       expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(simpleRoads);
     });
     it('can write the geoserver tiger_roads.sld', async () => {
@@ -539,7 +539,7 @@ describe('SldStyleParser implements StyleParser', () => {
       expect(errors).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(tiger_roads);
     });
     it('can write the geoserver pattern_polygon.sld', async () => {
@@ -551,7 +551,7 @@ describe('SldStyleParser implements StyleParser', () => {
       expect(errors).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(pattern_polygon);
     });
   });

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -45,8 +45,6 @@ import {
   XMLParser
 } from 'fast-xml-parser';
 
-import { isNumber, isString, merge } from 'lodash';
-
 import {
   Base64ImageObject,
   geoStylerFunctionToSldFunction,
@@ -55,8 +53,11 @@ import {
   getChildren,
   getParameterValue,
   getVendorOptionValue,
+  isNumber,
+  isString,
   isSymbolizer,
   keysByValue,
+  merge,
   numberExpression
 } from './Util/SldUtil';
 

--- a/src/SldStyleParser.v1.0.spec.ts
+++ b/src/SldStyleParser.v1.0.spec.ts
@@ -50,7 +50,7 @@ import functionFilterPropertyToProperty from '../data/styles/function_filter_pro
 import functionFilterOgcArithmetic from '../data/styles/function_filter_ogc_arithmetic';
 import functionLabelRound from '../data/styles/function_label_round';
 import point_externalgraphic_inlineContent from '../data/styles/point_externalgraphic_inlineContent';
-import {IconSymbolizer} from 'geostyler-style';
+import { IconSymbolizer } from 'geostyler-style';
 
 it('SldStyleParser is defined', () => {
   expect(SldStyleParser).toBeDefined();
@@ -60,7 +60,7 @@ describe('SldStyleParser implements StyleParser (reading)', () => {
   let styleParser: SldStyleParser;
 
   beforeEach(() => {
-    styleParser = new SldStyleParser({sldVersion: '1.0.0'});
+    styleParser = new SldStyleParser({ sldVersion: '1.0.0' });
   });
 
   describe('#readStyle', () => {
@@ -496,7 +496,7 @@ describe('SldStyleParser implements StyleParser (writing)', () => {
       // we read it again and compare the json input with the parser output
       const { output: readStyle } = await styleParser.readStyle(sldString!);
       // Check the image is not included in the output.
-      const symbolizer = readStyle?.rules[0]?.symbolizers[0] as IconSymbolizer|undefined;
+      const symbolizer = readStyle?.rules[0]?.symbolizers[0] as IconSymbolizer | undefined;
       expect(symbolizer).toBeDefined();
       expect(symbolizer?.image).toBeUndefined();
     });
@@ -852,7 +852,7 @@ describe('SldStyleParser implements StyleParser (writing)', () => {
       expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_simplepoint_filter_forceNumerics);
     });
     it('can write a SLD style with a filter and force cast of numeric fields (forceCasting)', async () => {
@@ -868,7 +868,7 @@ describe('SldStyleParser implements StyleParser (writing)', () => {
       expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_simplepoint_filter_forceNumerics);
     });
     it('can write a SLD style with a filter and force cast of boolean fields', async () => {
@@ -886,7 +886,7 @@ describe('SldStyleParser implements StyleParser (writing)', () => {
       expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_simplepoint_filter_forceBools);
     });
     it('can write a SLD style with a filter and force cast of boolean fields (forceCasting)', async () => {
@@ -903,7 +903,7 @@ describe('SldStyleParser implements StyleParser (writing)', () => {
       expect(unsupportedProperties).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_simplepoint_filter_forceBools);
     });
     it('can write a SLD style with nested logical filters', async () => {
@@ -976,7 +976,7 @@ describe('SldStyleParser implements StyleParser (writing)', () => {
       expect(errors).toBeUndefined();
       // As string comparison between two XML-Strings is awkward and nonsens
       // we read it again and compare the json input with the parser output
-      const { output: readStyle} = await styleParser.readStyle(sldString!);
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_styledLabel_literalOpenCurlyBraces);
     });
     it('can write a SLD style with a styled label containing placeholders and static text', async () => {
@@ -1065,7 +1065,7 @@ describe('SldStyleParser implements StyleParser (writing)', () => {
           format: true
         }
       });
-      const { output: sldString} = await styleParserOrder.writeStyle(point_styledLabel_elementOrder);
+      const { output: sldString } = await styleParserOrder.writeStyle(point_styledLabel_elementOrder);
       expect(sldString).toBeDefined();
       const sld = fs.readFileSync('./data/slds/1.0/point_styledLabel_elementOrder.sld', 'utf8');
       expect(sldString).toEqual(sld.trim());

--- a/src/Util/SldUtil.ts
+++ b/src/Util/SldUtil.ts
@@ -8,6 +8,7 @@ import {
 } from 'geostyler-style';
 import { SldVersion } from '../SldStyleParser';
 
+
 /**
  * Cast to Number if it is not a GeoStylerFunction
  *
@@ -266,7 +267,7 @@ export interface Base64ImageObject {
  * Get the data and extension from a base64 string.
  * @returns The data and extension or undefined if the string is not a base64 string.
  */
-export function getBase64Object (
+export function getBase64Object(
   base64String: string,
 ): Base64ImageObject | undefined {
   const baseTokens = base64String.split(',');
@@ -286,3 +287,47 @@ export function getBase64Object (
     extension: ext,
   };
 };
+
+
+/**
+ * Native replacement for lodash-es.
+ * https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore
+ *
+ * @param value The value to check.
+ * @returns Whether the value is a number or not.
+ */
+export function isNumber(value: unknown): value is number {
+  return typeof value === 'number' && !isNaN(value);
+}
+
+/**
+ * Native replacement for lodash-es.
+ * https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore
+ *
+ * @param value The value to check.
+ * @returns Whether the value is a string or not.
+ */
+export function isString(value: unknown): value is string {
+  if (value != null && typeof value.valueOf() === "string") {
+    return true
+  }
+  return false
+}
+
+/**
+ * Native replacement for lodash-es.
+ * https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore
+ *
+ * @param target The target object.
+ * @param source The source object.
+ * @returns The merged object.
+ */
+export function merge<T extends Record<string, any>, S extends Record<string, any>>(target: T, source: S): T & S {
+  for (const key in source as any) {
+    if (source[key] instanceof Object) {
+      Object.assign(source[key], merge(target[key] ?? {}, source[key]));
+    }
+  }
+  Object.assign(target || {}, source);
+  return target as T & S;
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,36 +1,8 @@
 {
+  "extends": "./tsconfig.json",
   "compilerOptions": {
-    "baseUrl": ".",
-    "declaration": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "inlineSources": true,
-    "lib": ["ES2022", "dom"],
-    "module": "Preserve",
-    "moduleResolution": "Bundler",
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "noImplicitThis": true,
-    "noUnusedLocals": true,
-    "outDir": "dist",
-    "rootDir": "src",
-    "sourceMap": true,
-    "strictNullChecks": true,
-    "target": "ES2022",
+    "rootDir": "src"
   },
-  "exclude": [
-    "**/*.spec.ts",
-    "node_modules",
-    "dist",
-    "scripts",
-    "acceptance-tests",
-    "coverage",
-    "webpack",
-    "jest",
-    "data",
-    "browser",
-    "browser-build.config.js",
-    "vite.config.ts",
-    "vitest.config.ts"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["**/*.spec.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "rootDir": ".",
     "sourceMap": true,
     "strictNullChecks": true,
-    "target": "ES2022",
+    "target": "ES2022"
   },
   "exclude": [
     "node_modules",
@@ -29,7 +29,8 @@
     "data",
     "browser",
     "browser-build.config.js",
-    "vite.config.ts",
+    "vite.config.browser.ts",
+    "vite.config.dist.ts",
     "vitest.config.ts"
   ]
 }

--- a/vite.config.browser.ts
+++ b/vite.config.browser.ts
@@ -17,9 +17,9 @@ export default defineConfig({
         exports: 'named',
         generatedCode: 'es5',
         format: 'iife',
-        sourcemap: true
       },
-    }
+    },
+    sourcemap: true
   },
   define: {
     appName: 'GeoStyler'

--- a/vite.config.dist.ts
+++ b/vite.config.dist.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from 'vite';
+import path from 'path';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [],
+  build: {
+    lib: {
+      entry: path.resolve(__dirname, 'src/SldStyleParser.ts'),
+      formats: ['es'],
+      fileName: 'SldStyleParser',
+    },
+    rollupOptions: {
+      external: ['geostyler-style', 'fast-xml-parser'],
+      output: {
+        dir: 'dist',
+        preserveModules: true,
+        preserveModulesRoot: 'src',
+        entryFileNames: '[name].js',
+        externalLiveBindings: false,
+      },
+    },
+    sourcemap: true,
+    outDir: 'dist',
+    emptyOutDir: true,
+  },
+});


### PR DESCRIPTION
Switch the build system to Vite and eliminate the dependency on Lodash by implementing native JavaScript alternatives for utility functions.

This should fix #1083 and #1043