### PR TITLE
fix: write sld arithmetic operators (#1109)

### DIFF
--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -130,14 +130,14 @@ type CombinationType = keyof typeof COMBINATION_MAP;
 const unitSldMetre: string = 'http://www.opengeospatial.org/se/units/metre';
 const unitSldPixel: string = 'http://www.opengeospatial.org/se/units/pixel';
 
-const ARITHMETIC_OPERATORS = [
+export const ARITHMETIC_OPERATORS = [
   'add',
   'sub',
   'mul',
   'div',
 ] as const;
 
-type ArithmeticType = typeof ARITHMETIC_OPERATORS[number];
+export type ArithmeticType = typeof ARITHMETIC_OPERATORS[number];
 
 export type SldStyleParserTranslationKeys = {
   marksymbolizerParseFailedUnknownWellknownName?: (params: { wellKnownName: string }) => string;

--- a/src/SldStyleParser.v1.0.spec.ts
+++ b/src/SldStyleParser.v1.0.spec.ts
@@ -981,6 +981,27 @@ describe('SldStyleParser implements StyleParser (writing)', () => {
       const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(functionFilterPropertyToProperty);
     });
+
+    it('can write a SLD with OGC arithmetic functions in a filter', async () => {
+      const {
+        output: sldString,
+        errors,
+        warnings,
+        unsupportedProperties
+      } = await styleParser.writeStyle(functionFilterOgcArithmetic);
+      expect(sldString).toBeDefined();
+      expect(errors).toBeUndefined();
+      expect(warnings).toBeUndefined();
+      expect(unsupportedProperties).toBeUndefined();
+      // As string comparison between two XML-Strings is awkward and nonsens
+      // we read it again and compare the json input with the parser output
+      const { output: readStyle } = await styleParser.readStyle(sldString!);
+      expect(readStyle).toEqual(functionFilterOgcArithmetic);
+      // Additional check that the arithmetic sld operator is not a "<Function name="mul">" but a SLD "<Mul>".
+      expect(sldString).toContain('</Mul>');
+      expect(sldString).toContain('</Div>');
+    });
+
     // it('can write a SLD style with functionfilters', async () => {
     //   const {
     //     output: sldString,

--- a/src/Util/SldUtil.ts
+++ b/src/Util/SldUtil.ts
@@ -6,7 +6,7 @@ import {
   isGeoStylerFunction,
   isGeoStylerNumberFunction, Fcustom
 } from 'geostyler-style';
-import { SldVersion } from '../SldStyleParser';
+import { SldVersion, ARITHMETIC_OPERATORS, type ArithmeticType } from '../SldStyleParser';
 
 
 /**
@@ -61,6 +61,13 @@ export function geoStylerFunctionToSldFunction(geostylerFunction: GeoStylerFunct
       };
     }
   });
+
+  if (ARITHMETIC_OPERATORS.includes(name.toLowerCase() as ArithmeticType)) {
+    const operatorSldName = name[0].toUpperCase() + name.slice(1).toLowerCase();
+    return [{
+      [operatorSldName]: sldFunctionArgs
+    }];
+  }
 
   return [{
     Function: sldFunctionArgs,


### PR DESCRIPTION
Fix #1109 

Dont' write add, sub, div, mul as function (`<Function name='add'>`), but write it using the right markup/operator: (`<Add>`)