### PR TITLE
Support expression in rotation

### DIFF
--- a/data/slds/1.0/point_geometry.sld
+++ b/data/slds/1.0/point_geometry.sld
@@ -28,6 +28,14 @@
                                 </Fill>
                             </Mark>
                             <Size>6</Size>
+                            <Rotation>
+                              <Add>
+                                <Function name="endAngle">
+                                  <PropertyName>shape</PropertyName>
+                                </Function>
+                                <Literal>180</Literal>
+                              </Add>
+                            </Rotation>
                         </Graphic>
                     </PointSymbolizer>
                 </Rule>

--- a/data/styles/point_geometry.ts
+++ b/data/styles/point_geometry.ts
@@ -11,6 +11,17 @@ const style: Style = {
           wellKnownName: 'square',
           color: '#FF0000',
           radius: 3,
+          rotate: {
+              name: 'add',
+              args: [{
+                name: 'custom',
+                fnName: 'endAngle',
+                args: [{
+                  name: 'property',
+                  args: ['shape']
+                }],
+            }, 180]
+          },
           geometry: {
              name: 'custom',
              fnName: 'endPoint',

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -2592,18 +2592,9 @@ export class SldStyleParser implements StyleParser<string> {
       const linePlacement: any = [];
 
       if (textSymbolizer.perpendicularOffset !== undefined) {
-        if (isGeoStylerFunction(textSymbolizer.perpendicularOffset)) {
-          const children = geoStylerFunctionToSldFunction(textSymbolizer.perpendicularOffset);
-          linePlacement.push({
-            [PerpendicularOffset]: children
-          });
-        } else {
-          linePlacement.push({
-            [PerpendicularOffset]: [{
-              '#text': textSymbolizer.perpendicularOffset.toString()
-            }]
-          });
-        }
+        linePlacement.push({
+          [PerpendicularOffset]: geoStylerFunctionOrTextToSld(textSymbolizer.perpendicularOffset)
+        });
       }
 
       // According to SLD 1.1 specification, isRepeated does not
@@ -2614,18 +2605,10 @@ export class SldStyleParser implements StyleParser<string> {
             '#text': true
           }]
         });
-        if (isGeoStylerFunction(textSymbolizer.repeat)) {
-          const children = geoStylerFunctionToSldFunction(textSymbolizer.repeat);
-          linePlacement.push({
-            [Gap]: children
-          });
-        } else {
-          linePlacement.push({
-            [Gap]: [{
-              '#text': textSymbolizer.repeat.toString()
-            }]
-          });
-        }
+
+        linePlacement.push({
+          [Gap]: geoStylerFunctionOrTextToSld(textSymbolizer.repeat)
+        });
       }
 
       sldTextSymbolizer.push({
@@ -3238,17 +3221,9 @@ export class SldStyleParser implements StyleParser<string> {
     }
     const Geometry = this.getTagName('Geometry');
     if (geometry) {
-      if (isGeoStylerFunction(geometry)) {
-        sldSymbolizerProperties.unshift({
-          [Geometry]: geoStylerFunctionToSldFunction(geometry)
-        });
-      } else {
-        sldSymbolizerProperties.unshift({
-          [Geometry]: [{
-            '#text': geometry
-          }]
-        });
-      }
+      sldSymbolizerProperties.unshift({
+        [Geometry]: geoStylerFunctionOrTextToSld(geometry)
+      });
     }
   }
 

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -46,7 +46,7 @@ import {
 } from 'fast-xml-parser';
 
 import {
-  Base64ImageObject,
+  Base64ImageObject, geoStylerFunctionOrTextToSld,
   geoStylerFunctionToSldFunction,
   get,
   getAttribute, getBase64Object,
@@ -58,7 +58,7 @@ import {
   isSymbolizer,
   keysByValue,
   merge,
-  numberExpression, sldFunctionToGeoStylerFunction
+  numberExpression, sldFunctionToGeoStylerFunction, sldNumberOperatorOrFunctionOrTextToGeostyler
 } from './Util/SldUtil';
 
 const SLD_VERSIONS = ['1.0.0', '1.1.0'] as const;
@@ -1027,9 +1027,9 @@ export class SldStyleParser implements StyleParser<string> {
         if (!isNil(offset)) {
           textSymbolizer.offset = offset;
         }
-        const rotation = get(pointPlacement, 'Rotation.#text');
+        const rotation = get(pointPlacement, 'Rotation');
         if (!isNil(rotation)) {
-          textSymbolizer.rotate = numberExpression(rotation);
+          textSymbolizer.rotate = sldNumberOperatorOrFunctionOrTextToGeostyler(rotation[0]);
         }
       } else if (!isNil(linePlacement)) {
         textSymbolizer.placement = 'line';
@@ -1296,7 +1296,7 @@ export class SldStyleParser implements StyleParser<string> {
 
     const opacity = get(sldMarkSymbolizer, 'Graphic.Opacity.#text');
     const size = get(sldMarkSymbolizer, 'Graphic.Size.#text');
-    const rotation = get(sldMarkSymbolizer, 'Graphic.Rotation.#text');
+    const rotation = get(sldMarkSymbolizer, 'Graphic.Rotation');
     const fillOpacity = getParameterValue(fillEl, 'fill-opacity', this.readingSldVersion);
     const color = getParameterValue(fillEl, 'fill', this.readingSldVersion);
     const displacement = get(sldMarkSymbolizer, 'Graphic.Displacement');
@@ -1316,7 +1316,7 @@ export class SldStyleParser implements StyleParser<string> {
       markSymbolizer.color = color;
     }
     if (!isNil(rotation)) {
-      markSymbolizer.rotate = numberExpression(rotation);
+      markSymbolizer.rotate = sldNumberOperatorOrFunctionOrTextToGeostyler(rotation[0]);
     }
     if (!isNil(size)) {
       // edge case where the value has to be divided by 2 which has to be considered in the function
@@ -1451,7 +1451,7 @@ export class SldStyleParser implements StyleParser<string> {
     };
     const opacity: string = get(sldIconSymbolizer, 'Graphic.Opacity.#text');
     const size: string = get(sldIconSymbolizer, 'Graphic.Size.#text');
-    const rotation: string = get(sldIconSymbolizer, 'Graphic.Rotation.#text');
+    const rotation = get(sldIconSymbolizer, 'Graphic.Rotation');
     const displacement = get(sldIconSymbolizer, 'Graphic.Displacement');
     if (!isNil(opacity)) {
       iconSymbolizer.opacity = numberExpression(opacity);
@@ -1463,7 +1463,7 @@ export class SldStyleParser implements StyleParser<string> {
       iconSymbolizer.sizeUnit = distanceUnit;
     }
     if (!isNil(rotation)) {
-      iconSymbolizer.rotate = numberExpression(rotation);
+      iconSymbolizer.rotate = sldNumberOperatorOrFunctionOrTextToGeostyler(rotation[0]);
     }
     const offset = this.getOffsetFromDisplacement(displacement);
     if (!isNil(offset)) {
@@ -2276,9 +2276,7 @@ export class SldStyleParser implements StyleParser<string> {
 
     if (markSymbolizer.rotate) {
       graphic.push({
-        [Rotation]: [{
-          '#text': markSymbolizer.rotate.toString()
-        }]
+        [Rotation]: geoStylerFunctionOrTextToSld(markSymbolizer.rotate)
       });
     }
 
@@ -2362,9 +2360,7 @@ export class SldStyleParser implements StyleParser<string> {
     }
     if (iconSymbolizer.rotate) {
       graphic.push({
-        [Rotation]: [{
-          '#text': iconSymbolizer.rotate,
-        }]
+        [Rotation]: geoStylerFunctionOrTextToSld(iconSymbolizer.rotate)
       });
     }
     if (iconSymbolizer.offset && this.sldVersion === '1.1.0') {
@@ -2671,9 +2667,7 @@ export class SldStyleParser implements StyleParser<string> {
       }
       if (textSymbolizer.rotate !== undefined) {
         pointPlacement.push({
-          [Rotation]: [{
-            '#text': textSymbolizer.rotate.toString()
-          }]
+          [Rotation]: geoStylerFunctionOrTextToSld(textSymbolizer.rotate)
         });
       }
       sldTextSymbolizer.push({

--- a/src/SldStyleParser.v1.0.spec.ts
+++ b/src/SldStyleParser.v1.0.spec.ts
@@ -817,6 +817,8 @@ describe('SldStyleParser implements StyleParser (writing)', () => {
       // we read it again and compare the json input with the parser output
       const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_geometry);
+      // Additional check that the arithmetic sld operator is not a "<Function name="add">" but a SLD "<Add>".
+      expect(sldString).toContain('</Add>');
     });
     it('can write a SLD TextSymbolizer', async () => {
       const {

--- a/src/Util/SldUtil.ts
+++ b/src/Util/SldUtil.ts
@@ -20,6 +20,15 @@ export function numberExpression(exp: Expression<PropertyType>): GeoStylerNumber
 }
 
 /**
+ * This converts a GeoStylerFunction or a value (toString) into a fast-xml-parser representation.
+ * @param value A GeoStylerFunction or a value that will ends as a text.
+ * @returns a a fast-xml-parser representation of the given value.
+ */
+export function geoStylerFunctionOrTextToSld(value: any): any {
+  return isGeoStylerFunction(value) ? geoStylerFunctionToSldFunction(value) : [{ '#text': value.toString() }];
+}
+
+/**
  * This converts a GeoStylerFunction into a fast-xml-parser representation
  * of a sld function.
  *
@@ -75,6 +84,37 @@ export function geoStylerFunctionToSldFunction(geostylerFunction: GeoStylerFunct
       '@_name': name === 'custom' ? (geostylerFunction as Fcustom).fnName : name
     }
   }];
+}
+
+/**
+ * This converts an expected number-like sldElement (text, literal, function a or operator resulting
+ * in a number) into a geostyler number or number Expression.
+ * @param sldElement an single objects as created by the fast-xml-parser
+ * @returns The number, number Expression<number> or undefined.
+ */
+export function sldNumberOperatorOrFunctionOrTextToGeostyler(sldElement: any):
+    number |
+    GeoStylerNumberFunction |
+    undefined
+{
+  if (sldElement?.['#text']) {
+    return numberExpression(sldElement['#text']);
+  }
+  if (sldElement?.Literal?.[0]?.['#text']) {
+    return sldElement?.Literal?.[0]?.['#text'];
+  }
+  if (sldElement?.[':@']?.['@_name']) {
+    return sldFunctionToGeoStylerFunction([sldElement]) as GeoStylerNumberFunction;
+  }
+  const operator = Object.keys(sldElement)[0];
+  const operatorName = operator.toLowerCase() as ArithmeticType;
+  if (ARITHMETIC_OPERATORS.includes(operatorName)) {
+    return {
+      name: operatorName,
+      args: sldElement[operator]?.map((sldEle: any) => sldNumberOperatorOrFunctionOrTextToGeostyler(sldEle)) ?? []
+    };
+  }
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
Feature #1104 

Now, `rotation` can be a `number` or an `Expression<number>`