### PR TITLE
fix: prefix filter and expression with the ogc namespace (#1112)

### DIFF
--- a/data/slds/1.0/empty_filter.sld
+++ b/data/slds/1.0/empty_filter.sld
@@ -8,7 +8,7 @@
       <FeatureTypeStyle>
         <Rule>
           <Name>Cities &amp; Towns</Name>
-          <Filter xmlns="http://www.opengis.net/ogc"/>
+          <ogc:Filter xmlns="http://www.opengis.net/ogc"/>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#FFE15A</CssParameter>

--- a/data/slds/1.0/function_filter.sld
+++ b/data/slds/1.0/function_filter.sld
@@ -8,16 +8,16 @@
       <FeatureTypeStyle>
         <Rule>
           <Name>Function Property Rule 0</Name>
-          <Filter xmlns="http://www.opengis.net/ogc">
-            <Function name="equalTo">
-              <Function name="between">
-                <PropertyName>testprop</PropertyName>
-                <Literal>0</Literal>
-                <Literal>1</Literal>
-              </Function>
-              <Literal>true</Literal>
-            </Function>
-          </Filter>
+          <ogc:Filter xmlns="http://www.opengis.net/ogc">
+            <ogc:Function name="equalTo">
+              <ogc:Function name="between">
+                <ogc:PropertyName>testprop</ogc:PropertyName>
+                <ogc:Literal>0</ogc:Literal>
+                <ogc:Literal>1</ogc:Literal>
+              </ogc:Function>
+              <ogc:Literal>true</ogc:Literal>
+            </ogc:Function>
+          </ogc:Filter>
           <PointSymbolizer>
             <Graphic>
               <Mark>

--- a/data/slds/1.0/function_markSymbolizer.sld
+++ b/data/slds/1.0/function_markSymbolizer.sld
@@ -20,7 +20,7 @@
                 </Fill>
               </Mark>
               <Size>
-                <Function name="pi" />
+                <ogc:Function name="pi" />
               </Size>
             </Graphic>
           </PointSymbolizer>

--- a/data/slds/1.0/function_nested.sld
+++ b/data/slds/1.0/function_nested.sld
@@ -14,12 +14,12 @@
             </Fill>
             <Stroke>
               <CssParameter name="stroke-width">
-                <Function name="max">
-                  <Function name="pi" />
-                  <Function name="strLength">
-                    <Literal>Peter</Literal>
-                  </Function>
-                </Function>
+                <ogc:Function name="max">
+                  <ogc:Function name="pi" />
+                  <ogc:Function name="strLength">
+                    <ogc:Literal>Peter</ogc:Literal>
+                  </ogc:Function>
+                </ogc:Function>
             </CssParameter>
             </Stroke>
           </PolygonSymbolizer>

--- a/data/slds/1.0/point_geometry.sld
+++ b/data/slds/1.0/point_geometry.sld
@@ -16,9 +16,9 @@
                     <Abstract>A red square at the end of the line</Abstract>
                     <PointSymbolizer>
                         <Geometry>
-                            <Function name="endPoint">
-                                <PropertyName>shape</PropertyName>
-                            </Function>
+                            <ogc:Function name="endPoint">
+                                <ogc:PropertyName>shape</ogc:PropertyName>
+                            </ogc:Function>
                         </Geometry>
                         <Graphic>
                             <Mark>
@@ -29,12 +29,12 @@
                             </Mark>
                             <Size>6</Size>
                             <Rotation>
-                              <Add>
-                                <Function name="endAngle">
-                                  <PropertyName>shape</PropertyName>
-                                </Function>
-                                <Literal>180</Literal>
-                              </Add>
+                              <ogc:Add>
+                                <ogc:Function name="endAngle">
+                                  <ogc:PropertyName>shape</ogc:PropertyName>
+                                </ogc:Function>
+                                <ogc:Literal>180</ogc:Literal>
+                              </ogc:Add>
                             </Rotation>
                         </Graphic>
                     </PointSymbolizer>

--- a/data/slds/1.0/point_simplepoint_filter.sld
+++ b/data/slds/1.0/point_simplepoint_filter.sld
@@ -11,54 +11,54 @@
       <FeatureTypeStyle>
         <Rule>
           <Name>Small populated New Yorks</Name>
-          <Filter xmlns="http://www.opengis.net/ogc">
-            <And>
-              <PropertyIsEqualTo>
-                <PropertyName>NAME</PropertyName>
-                <Literal>New York</Literal>
-              </PropertyIsEqualTo>
-              <PropertyIsEqualTo>
-                <PropertyName>TEST_BOOL</PropertyName>
-                <Literal>true</Literal>
-              </PropertyIsEqualTo>
-              <PropertyIsNull>
-                <PropertyName>TEST</PropertyName>
-              </PropertyIsNull>
-              <PropertyIsLike wildCard="*" singleChar="." escape="!">
-                <PropertyName>TEST2</PropertyName>
-                <Literal>*York*</Literal>
-              </PropertyIsLike>
-              <PropertyIsLike wildCard="*" singleChar="." escape="!">
-                <PropertyName>TEST1</PropertyName>
-                <Literal>*New*</Literal>
-              </PropertyIsLike>
-              <Not>
-                <PropertyIsGreaterThan>
-                  <PropertyName>POPULATION</PropertyName>
-                  <Literal>100000</Literal>
-                </PropertyIsGreaterThan>
-              </Not>
-              <Or>
-                <PropertyIsEqualTo>
-                  <PropertyName>TEST2</PropertyName>
-                  <Literal>1</Literal>
-                </PropertyIsEqualTo>
-                <PropertyIsEqualTo>
-                  <PropertyName>TEST2</PropertyName>
-                  <Literal>2</Literal>
-                </PropertyIsEqualTo>
-              </Or>
-              <PropertyIsBetween>
-                <PropertyName>TEST3</PropertyName>
+          <ogc:Filter xmlns="http://www.opengis.net/ogc">
+            <ogc:And>
+              <ogc:PropertyIsEqualTo>
+                <ogc:PropertyName>NAME</ogc:PropertyName>
+                <ogc:Literal>New York</ogc:Literal>
+              </ogc:PropertyIsEqualTo>
+              <ogc:PropertyIsEqualTo>
+                <ogc:PropertyName>TEST_BOOL</ogc:PropertyName>
+                <ogc:Literal>true</ogc:Literal>
+              </ogc:PropertyIsEqualTo>
+              <ogc:PropertyIsNull>
+                <ogc:PropertyName>TEST</ogc:PropertyName>
+              </ogc:PropertyIsNull>
+              <ogc:PropertyIsLike wildCard="*" singleChar="." escape="!">
+                <ogc:PropertyName>TEST2</ogc:PropertyName>
+                <ogc:Literal>*York*</ogc:Literal>
+              </ogc:PropertyIsLike>
+              <ogc:PropertyIsLike wildCard="*" singleChar="." escape="!">
+                <ogc:PropertyName>TEST1</ogc:PropertyName>
+                <ogc:Literal>*New*</ogc:Literal>
+              </ogc:PropertyIsLike>
+              <ogc:Not>
+                <ogc:PropertyIsGreaterThan>
+                  <ogc:PropertyName>POPULATION</ogc:PropertyName>
+                  <ogc:Literal>100000</ogc:Literal>
+                </ogc:PropertyIsGreaterThan>
+              </ogc:Not>
+              <ogc:Or>
+                <ogc:PropertyIsEqualTo>
+                  <ogc:PropertyName>TEST2</ogc:PropertyName>
+                  <ogc:Literal>1</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+                <ogc:PropertyIsEqualTo>
+                  <ogc:PropertyName>TEST2</ogc:PropertyName>
+                  <ogc:Literal>2</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+              </ogc:Or>
+              <ogc:PropertyIsBetween>
+                <ogc:PropertyName>TEST3</ogc:PropertyName>
                 <LowerBoundary>
-                  <Literal>1</Literal>
+                  <ogc:Literal>1</ogc:Literal>
                 </LowerBoundary>
                 <UpperBoundary>
-                  <Literal>5</Literal>
+                  <ogc:Literal>5</ogc:Literal>
                 </UpperBoundary>
-              </PropertyIsBetween>
-            </And>
-          </Filter>
+              </ogc:PropertyIsBetween>
+            </ogc:And>
+          </ogc:Filter>
           <MinScaleDenominator>10000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PointSymbolizer>

--- a/data/slds/1.0/point_simplepoint_functionfilter.sld
+++ b/data/slds/1.0/point_simplepoint_functionfilter.sld
@@ -11,15 +11,15 @@
       <FeatureTypeStyle>
         <Rule>
           <Name>Small populated New Yorks</Name>
-          <Filter xmlns="http://www.opengis.net/ogc">
-            <PropertyIsLike>
-              <Function name="strMatches">
-                <PropertyName>year</PropertyName>
-                <Literal>^( )??2019,.*</Literal>
-              </Function>
-              <Literal>true</Literal>
-            </PropertyIsLike>
-          </Filter>
+          <ogc:Filter xmlns="http://www.opengis.net/ogc">
+            <ogc:PropertyIsLike>
+              <ogc:Function name="strMatches">
+                <ogc:PropertyName>year</ogc:PropertyName>
+                <ogc:Literal>^( )??2019,.*</ogc:Literal>
+              </ogc:Function>
+              <ogc:Literal>true</ogc:Literal>
+            </ogc:PropertyIsLike>
+          </ogc:Filter>
           <MinScaleDenominator>10000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PointSymbolizer>

--- a/data/slds/1.0/point_simplepoint_nestedLogicalFilters.sld
+++ b/data/slds/1.0/point_simplepoint_nestedLogicalFilters.sld
@@ -11,40 +11,40 @@
       <FeatureTypeStyle>
         <Rule>
           <Name>Test</Name>
-          <Filter xmlns="http://www.opengis.net/ogc">
-            <And>
-              <Or>
-                <PropertyIsEqualTo>
-                  <PropertyName>ID</PropertyName>
-                  <Literal>1</Literal>
-                </PropertyIsEqualTo>
-                <PropertyIsEqualTo>
-                  <PropertyName>ID</PropertyName>
-                  <Literal>2</Literal>
-                </PropertyIsEqualTo>
-              </Or>
-              <Or>
-                <PropertyIsEqualTo>
-                  <PropertyName>STREET</PropertyName>
-                  <Literal>Main</Literal>
-                </PropertyIsEqualTo>
-                <PropertyIsEqualTo>
-                  <PropertyName>STREET</PropertyName>
-                  <Literal>Time square</Literal>
-                </PropertyIsEqualTo>
-                <And>
-                  <PropertyIsGreaterThanOrEqualTo>
-                    <PropertyName>HOUSENO</PropertyName>
-                    <Literal>1909</Literal>
-                  </PropertyIsGreaterThanOrEqualTo>
-                  <PropertyIsLessThanOrEqualTo>
-                    <PropertyName>HOUSENO</PropertyName>
-                    <Literal>19909</Literal>
-                  </PropertyIsLessThanOrEqualTo>
-                </And>
-              </Or>
-            </And>
-          </Filter>
+          <ogc:Filter xmlns="http://www.opengis.net/ogc">
+            <ogc:And>
+              <ogc:Or>
+                <ogc:PropertyIsEqualTo>
+                  <ogc:PropertyName>ID</ogc:PropertyName>
+                  <ogc:Literal>1</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+                <ogc:PropertyIsEqualTo>
+                  <ogc:PropertyName>ID</ogc:PropertyName>
+                  <ogc:Literal>2</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+              </ogc:Or>
+              <ogc:Or>
+                <ogc:PropertyIsEqualTo>
+                  <ogc:PropertyName>STREET</ogc:PropertyName>
+                  <ogc:Literal>Main</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+                <ogc:PropertyIsEqualTo>
+                  <ogc:PropertyName>STREET</ogc:PropertyName>
+                  <ogc:Literal>Time square</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+                <ogc:And>
+                  <ogc:PropertyIsGreaterThanOrEqualTo>
+                    <ogc:PropertyName>HOUSENO</ogc:PropertyName>
+                    <ogc:Literal>1909</ogc:Literal>
+                  </ogc:PropertyIsGreaterThanOrEqualTo>
+                  <ogc:PropertyIsLessThanOrEqualTo>
+                    <ogc:PropertyName>HOUSENO</ogc:PropertyName>
+                    <ogc:Literal>19909</ogc:Literal>
+                  </ogc:PropertyIsLessThanOrEqualTo>
+                </ogc:And>
+              </ogc:Or>
+            </ogc:And>
+          </ogc:Filter>
           <MinScaleDenominator>10000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PointSymbolizer>

--- a/data/slds/1.1/function_filter.sld
+++ b/data/slds/1.1/function_filter.sld
@@ -15,16 +15,16 @@
       <se:FeatureTypeStyle>
         <se:Rule>
           <se:Name>Function Property Rule 0</se:Name>
-          <Filter xmlns="http://www.opengis.net/ogc">
-            <Function name="equalTo">
-              <Function name="between">
-                <PropertyName>testprop</PropertyName>
-                <Literal>0</Literal>
-                <Literal>1</Literal>
-              </Function>
-              <Literal>true</Literal>
-            </Function>
-          </Filter>
+          <ogc:Filter xmlns="http://www.opengis.net/ogc">
+            <ogc:Function name="equalTo">
+              <ogc:Function name="between">
+                <ogc:PropertyName>testprop</ogc:PropertyName>
+                <ogc:Literal>0</ogc:Literal>
+                <ogc:Literal>1</ogc:Literal>
+              </ogc:Function>
+              <ogc:Literal>true</ogc:Literal>
+            </ogc:Function>
+          </ogc:Filter>
           <se:PointSymbolizer>
             <se:Graphic>
               <se:Mark>

--- a/data/slds/1.1/function_filter_property_to_property.sld
+++ b/data/slds/1.1/function_filter_property_to_property.sld
@@ -12,34 +12,34 @@
             <se:FeatureTypeStyle>
                 <se:Rule>
                     <se:Name>Property Comparison Rule</se:Name>
-                    <Filter xmlns="http://www.opengis.net/ogc">
-                        <And>
-                            <PropertyIsEqualTo>
-                                <PropertyName>posledni_hodnota</PropertyName>
-                                <PropertyName>posledni_hodnota_sekundarni</PropertyName>
-                            </PropertyIsEqualTo>
-                            <PropertyIsGreaterThan>
-                                <PropertyName>value1</PropertyName>
-                                <PropertyName>value2</PropertyName>
-                            </PropertyIsGreaterThan>
-                            <PropertyIsLessThan>
-                                <PropertyName>count1</PropertyName>
-                                <PropertyName>count2</PropertyName>
-                            </PropertyIsLessThan>
-                            <PropertyIsGreaterThanOrEqualTo>
-                                <PropertyName>threshold1</PropertyName>
-                                <PropertyName>threshold2</PropertyName>
-                            </PropertyIsGreaterThanOrEqualTo>
-                            <Function name="lessThanOrEqualTo">
-                                <PropertyName>posledni_hodnota</PropertyName>
-                                <PropertyName>spa1h</PropertyName>
-                            </Function>
-                            <PropertyIsNotEqualTo>
-                                <PropertyName>status</PropertyName>
-                                <Literal>NULL</Literal>
-                            </PropertyIsNotEqualTo>
-                        </And>
-                    </Filter>
+                    <ogc:Filter xmlns="http://www.opengis.net/ogc">
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>posledni_hodnota</ogc:PropertyName>
+                                <ogc:PropertyName>posledni_hodnota_sekundarni</ogc:PropertyName>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsGreaterThan>
+                                <ogc:PropertyName>value1</ogc:PropertyName>
+                                <ogc:PropertyName>value2</ogc:PropertyName>
+                            </ogc:PropertyIsGreaterThan>
+                            <ogc:PropertyIsLessThan>
+                                <ogc:PropertyName>count1</ogc:PropertyName>
+                                <ogc:PropertyName>count2</ogc:PropertyName>
+                            </ogc:PropertyIsLessThan>
+                            <ogc:PropertyIsGreaterThanOrEqualTo>
+                                <ogc:PropertyName>threshold1</ogc:PropertyName>
+                                <ogc:PropertyName>threshold2</ogc:PropertyName>
+                            </ogc:PropertyIsGreaterThanOrEqualTo>
+                            <ogc:Function name="lessThanOrEqualTo">
+                                <ogc:PropertyName>posledni_hodnota</ogc:PropertyName>
+                                <ogc:PropertyName>spa1h</ogc:PropertyName>
+                            </ogc:Function>
+                            <ogc:PropertyIsNotEqualTo>
+                                <ogc:PropertyName>status</ogc:PropertyName>
+                                <ogc:Literal>NULL</ogc:Literal>
+                            </ogc:PropertyIsNotEqualTo>
+                        </ogc:And>
+                    </ogc:Filter>
                     <se:PointSymbolizer>
                         <se:Graphic>
                             <se:Mark>

--- a/data/slds/1.1/point_simplepoint_filter.sld
+++ b/data/slds/1.1/point_simplepoint_filter.sld
@@ -7,54 +7,54 @@
       <se:FeatureTypeStyle>
         <se:Rule>
           <se:Name>Small populated New Yorks</se:Name>
-          <Filter xmlns="http://www.opengis.net/ogc">
-            <And>
-              <PropertyIsEqualTo>
-                <PropertyName>NAME</PropertyName>
-                <Literal>New York</Literal>
-              </PropertyIsEqualTo>
-              <PropertyIsEqualTo>
-                <PropertyName>TEST_BOOL</PropertyName>
-                <Literal>true</Literal>
-              </PropertyIsEqualTo>
-              <PropertyIsNull>
-                <PropertyName>TEST</PropertyName>
-              </PropertyIsNull>
-              <PropertyIsLike wildCard="*" singleChar="." escapeChar="!">
-                <PropertyName>TEST2</PropertyName>
-                <Literal>*York*</Literal>
-              </PropertyIsLike>
-              <PropertyIsLike wildCard="*" singleChar="." escapeChar="!">
-                <PropertyName>TEST1</PropertyName>
-                <Literal>*New*</Literal>
-              </PropertyIsLike>
-              <Not>
-                <PropertyIsGreaterThan>
-                  <PropertyName>POPULATION</PropertyName>
-                  <Literal>100000</Literal>
-                </PropertyIsGreaterThan>
-              </Not>
-              <Or>
-                <PropertyIsEqualTo>
-                  <PropertyName>TEST2</PropertyName>
-                  <Literal>1</Literal>
-                </PropertyIsEqualTo>
-                <PropertyIsEqualTo>
-                  <PropertyName>TEST2</PropertyName>
-                  <Literal>2</Literal>
-                </PropertyIsEqualTo>
-              </Or>
-              <PropertyIsBetween>
-                <PropertyName>TEST3</PropertyName>
+          <ogc:Filter xmlns="http://www.opengis.net/ogc">
+            <ogc:And>
+              <ogc:PropertyIsEqualTo>
+                <ogc:PropertyName>NAME</ogc:PropertyName>
+                <ogc:Literal>New York</ogc:Literal>
+              </ogc:PropertyIsEqualTo>
+              <ogc:PropertyIsEqualTo>
+                <ogc:PropertyName>TEST_BOOL</ogc:PropertyName>
+                <ogc:Literal>true</ogc:Literal>
+              </ogc:PropertyIsEqualTo>
+              <ogc:PropertyIsNull>
+                <ogc:PropertyName>TEST</ogc:PropertyName>
+              </ogc:PropertyIsNull>
+              <ogc:PropertyIsLike wildCard="*" singleChar="." escapeChar="!">
+                <ogc:PropertyName>TEST2</ogc:PropertyName>
+                <ogc:Literal>*York*</ogc:Literal>
+              </ogc:PropertyIsLike>
+              <ogc:PropertyIsLike wildCard="*" singleChar="." escapeChar="!">
+                <ogc:PropertyName>TEST1</ogc:PropertyName>
+                <ogc:Literal>*New*</ogc:Literal>
+              </ogc:PropertyIsLike>
+              <ogc:Not>
+                <ogc:PropertyIsGreaterThan>
+                  <ogc:PropertyName>POPULATION</ogc:PropertyName>
+                  <ogc:Literal>100000</ogc:Literal>
+                </ogc:PropertyIsGreaterThan>
+              </ogc:Not>
+              <ogc:Or>
+                <ogc:PropertyIsEqualTo>
+                  <ogc:PropertyName>TEST2</ogc:PropertyName>
+                  <ogc:Literal>1</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+                <ogc:PropertyIsEqualTo>
+                  <ogc:PropertyName>TEST2</ogc:PropertyName>
+                  <ogc:Literal>2</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+              </ogc:Or>
+              <ogc:PropertyIsBetween>
+                <ogc:PropertyName>TEST3</ogc:PropertyName>
                 <LowerBoundary>
-                  <Literal>1</Literal>
+                  <ogc:Literal>1</ogc:Literal>
                 </LowerBoundary>
                 <UpperBoundary>
-                  <Literal>5</Literal>
+                  <ogc:Literal>5</ogc:Literal>
                 </UpperBoundary>
-              </PropertyIsBetween>
-            </And>
-          </Filter>
+              </ogc:PropertyIsBetween>
+            </ogc:And>
+          </ogc:Filter>
           <se:MinScaleDenominator>10000</se:MinScaleDenominator>
           <se:MaxScaleDenominator>20000</se:MaxScaleDenominator>
           <se:PointSymbolizer>

--- a/data/slds/1.1/point_simplepoint_functionfilter.sld
+++ b/data/slds/1.1/point_simplepoint_functionfilter.sld
@@ -7,15 +7,15 @@
       <se:FeatureTypeStyle>
         <se:Rule>
           <se:Name>Small populated New Yorks</se:Name>
-          <Filter xmlns="http://www.opengis.net/ogc">
-            <PropertyIsLike wildCard="*" singleChar="." escapeChar="!">
-              <Function name="strMatches">
-                <PropertyName>year</PropertyName>
-                <Literal>^( )??2019,.*</Literal>
-              </Function>
-              <Literal>true</Literal>
-            </PropertyIsLike>
-          </Filter>
+          <ogc:Filter xmlns="http://www.opengis.net/ogc">
+            <ogc:PropertyIsLike wildCard="*" singleChar="." escapeChar="!">
+              <ogc:Function name="strMatches">
+                <ogc:PropertyName>year</ogc:PropertyName>
+                <ogc:Literal>^( )??2019,.*</ogc:Literal>
+              </ogc:Function>
+              <ogc:Literal>true</ogc:Literal>
+            </ogc:PropertyIsLike>
+          </ogc:Filter>
           <se:MinScaleDenominator>10000</se:MinScaleDenominator>
           <se:MaxScaleDenominator>20000</se:MaxScaleDenominator>
           <se:PointSymbolizer>

--- a/data/slds/1.1/point_simplepoint_nestedLogicalFilters.sld
+++ b/data/slds/1.1/point_simplepoint_nestedLogicalFilters.sld
@@ -7,40 +7,40 @@
       <se:FeatureTypeStyle>
         <se:Rule>
           <se:Name>Test</se:Name>
-          <Filter xmlns="http://www.opengis.net/ogc">
-            <And>
-              <Or>
-                <PropertyIsEqualTo>
-                  <PropertyName>ID</PropertyName>
-                  <Literal>1</Literal>
-                </PropertyIsEqualTo>
-                <PropertyIsEqualTo>
-                  <PropertyName>ID</PropertyName>
-                  <Literal>2</Literal>
-                </PropertyIsEqualTo>
-              </Or>
-              <Or>
-                <PropertyIsEqualTo>
-                  <PropertyName>STREET</PropertyName>
-                  <Literal>Main</Literal>
-                </PropertyIsEqualTo>
-                <PropertyIsEqualTo>
-                  <PropertyName>STREET</PropertyName>
-                  <Literal>Time square</Literal>
-                </PropertyIsEqualTo>
-                <And>
-                  <PropertyIsGreaterThanOrEqualTo>
-                    <PropertyName>HOUSENO</PropertyName>
-                    <Literal>1909</Literal>
-                  </PropertyIsGreaterThanOrEqualTo>
-                  <PropertyIsLessThanOrEqualTo>
-                    <PropertyName>HOUSENO</PropertyName>
-                    <Literal>19909</Literal>
-                  </PropertyIsLessThanOrEqualTo>
-                </And>
-              </Or>
-            </And>
-          </Filter>
+          <ogc:Filter xmlns="http://www.opengis.net/ogc">
+            <ogc:And>
+              <ogc:Or>
+                <ogc:PropertyIsEqualTo>
+                  <ogc:PropertyName>ID</ogc:PropertyName>
+                  <ogc:Literal>1</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+                <ogc:PropertyIsEqualTo>
+                  <ogc:PropertyName>ID</ogc:PropertyName>
+                  <ogc:Literal>2</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+              </ogc:Or>
+              <ogc:Or>
+                <ogc:PropertyIsEqualTo>
+                  <ogc:PropertyName>STREET</ogc:PropertyName>
+                  <ogc:Literal>Main</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+                <ogc:PropertyIsEqualTo>
+                  <ogc:PropertyName>STREET</ogc:PropertyName>
+                  <ogc:Literal>Time square</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+                <ogc:And>
+                  <ogc:PropertyIsGreaterThanOrEqualTo>
+                    <ogc:PropertyName>HOUSENO</ogc:PropertyName>
+                    <ogc:Literal>1909</ogc:Literal>
+                  </ogc:PropertyIsGreaterThanOrEqualTo>
+                  <ogc:PropertyIsLessThanOrEqualTo>
+                    <ogc:PropertyName>HOUSENO</ogc:PropertyName>
+                    <ogc:Literal>19909</ogc:Literal>
+                  </ogc:PropertyIsLessThanOrEqualTo>
+                </ogc:And>
+              </ogc:Or>
+            </ogc:And>
+          </ogc:Filter>
           <se:MinScaleDenominator>10000</se:MinScaleDenominator>
           <se:MaxScaleDenominator>20000</se:MaxScaleDenominator>
           <se:PointSymbolizer>

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -1813,7 +1813,10 @@ export class SldStyleParser implements StyleParser<string> {
     const sldOperator: string = (sldOperators.length > 1 && value === null)
       ? sldOperators[1] : sldOperators[0];
 
-    const propertyKey = 'PropertyName';
+    const sldOperatorElement = `ogc:${sldOperator}`;
+    const functionElement = 'ogc:Function';
+    const propertyKeyElement = 'ogc:PropertyName';
+    const literalElement = 'ogc:Literal';
 
     if (isGeoStylerFunction(key) || isGeoStylerFunction(value)) {
       const tempOperator = sldOperator.replace('PropertyIs', '');
@@ -1827,7 +1830,7 @@ export class SldStyleParser implements StyleParser<string> {
         functionChildren.unshift(Array.isArray(keyResult) ? keyResult?.[0] : keyResult);
       } else {
         functionChildren.unshift({
-          Literal: [{
+          [literalElement]: [{
             '#text': keyResult
           }]
         });
@@ -1837,14 +1840,14 @@ export class SldStyleParser implements StyleParser<string> {
         functionChildren.push(Array.isArray(valueResult) ? valueResult?.[0] : valueResult);
       } else {
         functionChildren.push({
-          Literal: [{
+          [literalElement]: [{
             '#text': valueResult
           }]
         });
       }
 
       return [{
-        Function: functionChildren,
+        [functionElement]: functionChildren,
         ':@': {
           '@_name': sldFunctionOperator
         }
@@ -1854,20 +1857,20 @@ export class SldStyleParser implements StyleParser<string> {
     if (sldOperator === 'PropertyIsNull') {
       // empty, selfclosing Literals are not valid in a propertyIsNull filter
       sldComparisonFilter.push({
-        [sldOperator]: [{
-          [propertyKey]: [{
+        [sldOperatorElement]: [{
+          [propertyKeyElement]: [{
             '#text': key
           }]
         }]
       });
     } else if (sldOperator === 'PropertyIsLike') {
       sldComparisonFilter.push({
-        [sldOperator]: [{
-          [propertyKey]: [{
+        [sldOperatorElement]: [{
+          [propertyKeyElement]: [{
             '#text': key
           }]
         }, {
-          Literal: [{
+          [literalElement]: [{
             '#text': value
           }]
         }],
@@ -1881,19 +1884,19 @@ export class SldStyleParser implements StyleParser<string> {
       // Currently we only support Literals as values.
       const betweenFilter = comparisonFilter as RangeFilter;
       sldComparisonFilter.push({
-        [sldOperator]: [{
-          [propertyKey]: [{
+        [sldOperatorElement]: [{
+          [propertyKeyElement]: [{
             '#text': key
           }]
         }, {
-          LowerBoundary: [{
-            Literal: [{
+          'ogc:LowerBoundary': [{
+            [literalElement]: [{
               '#text': betweenFilter[2]
             }]
           }]
         }, {
-          UpperBoundary: [{
-            Literal: [{
+          'ogc:UpperBoundary': [{
+            [literalElement]: [{
               '#text': betweenFilter[3]
             }]
           }]
@@ -1901,12 +1904,12 @@ export class SldStyleParser implements StyleParser<string> {
       });
     } else {
       sldComparisonFilter.push({
-        [sldOperator]: [{
-          [propertyKey]: [{
+        [sldOperatorElement]: [{
+          [propertyKeyElement]: [{
             '#text': key
           }]
         }, {
-          Literal: [{
+          [literalElement]: [{
             '#text': value
           }]
         }]
@@ -1930,7 +1933,7 @@ export class SldStyleParser implements StyleParser<string> {
       sldFilter = this.getSldComparisonFilterFromComparisonFilter(filter);
     } else if (isNegationFilter(filter)) {
       sldFilter.push({
-        Not: this.getSldFilterFromFilter(filter[1])
+        'ogc:Not': this.getSldFilterFromFilter(filter[1])
       });
     } else if (isCombinationFilter(filter)) {
       const [
@@ -1941,7 +1944,7 @@ export class SldStyleParser implements StyleParser<string> {
       const combinator = sldOperators[0];
       const sldSubFilters = args.map(subFilter => this.getSldFilterFromFilter(subFilter)[0]);
       sldFilter.push({
-        [combinator]: sldSubFilters
+        [`ogc:${combinator}`]: sldSubFilters
       });
     }
     return sldFilter;

--- a/src/SldStyleParser.v1.0.spec.ts
+++ b/src/SldStyleParser.v1.0.spec.ts
@@ -817,8 +817,8 @@ describe('SldStyleParser implements StyleParser (writing)', () => {
       // we read it again and compare the json input with the parser output
       const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(point_geometry);
-      // Additional check that the arithmetic sld operator is not a "<Function name="add">" but a SLD "<Add>".
-      expect(sldString).toContain('</Add>');
+      // Additional check that the arithmetic sld operator is not a "<Function name="add">" but a SLD "<ogc:Add>".
+      expect(sldString).toContain('</ogc:Add>');
     });
     it('can write a SLD TextSymbolizer', async () => {
       const {
@@ -999,9 +999,9 @@ describe('SldStyleParser implements StyleParser (writing)', () => {
       // we read it again and compare the json input with the parser output
       const { output: readStyle } = await styleParser.readStyle(sldString!);
       expect(readStyle).toEqual(functionFilterOgcArithmetic);
-      // Additional check that the arithmetic sld operator is not a "<Function name="mul">" but a SLD "<Mul>".
-      expect(sldString).toContain('</Mul>');
-      expect(sldString).toContain('</Div>');
+      // Additional check that the arithmetic sld operator is not a "<Function name="mul">" but a SLD "<ogc:Mul>".
+      expect(sldString).toContain('</ogc:Mul>');
+      expect(sldString).toContain('</ogc:Div>');
     });
 
     // it('can write a SLD style with functionfilters', async () => {

--- a/src/Util/SldUtil.ts
+++ b/src/Util/SldUtil.ts
@@ -43,7 +43,7 @@ export function geoStylerFunctionToSldFunction(geostylerFunction: GeoStylerFunct
   // TODO: Typing of functions without args should be refactored in geostyler-style
   if (name === 'pi' || name === 'random') {
     return [{
-      Function: [],
+      'ogc:Function': [],
       ':@': {
         '@_name': name
       }
@@ -52,7 +52,7 @@ export function geoStylerFunctionToSldFunction(geostylerFunction: GeoStylerFunct
 
   if (name === 'property') {
     return {
-      PropertyName: [{
+      'ogc:PropertyName': [{
         '#text': geostylerFunction.args[0]
       }]
     };
@@ -64,7 +64,7 @@ export function geoStylerFunctionToSldFunction(geostylerFunction: GeoStylerFunct
       return Array.isArray(argAsFunction) ? argAsFunction[0] : argAsFunction;
     } else {
       return {
-        Literal: [{
+        'ogc:Literal': [{
           '#text': arg
         }]
       };
@@ -72,14 +72,14 @@ export function geoStylerFunctionToSldFunction(geostylerFunction: GeoStylerFunct
   });
 
   if (ARITHMETIC_OPERATORS.includes(name.toLowerCase() as ArithmeticType)) {
-    const operatorSldName = name[0].toUpperCase() + name.slice(1).toLowerCase();
+    const operatorSldElement = 'ogc:' + name[0].toUpperCase() + name.slice(1).toLowerCase();
     return [{
-      [operatorSldName]: sldFunctionArgs
+      [operatorSldElement]: sldFunctionArgs
     }];
   }
 
   return [{
-    Function: sldFunctionArgs,
+    'ogc:Function': sldFunctionArgs,
     ':@': {
       '@_name': name === 'custom' ? (geostylerFunction as Fcustom).fnName : name
     }


### PR DESCRIPTION
BREAKING CHANGE: All expressions, filters and operators are now prefixed with the ogc namespace. If your code previously expected these elements to not have a prefix (e.g. <Add> instead of <ogc:Add>), you now have to adjust it accordingly.

Fix #1112 

"Fun" fact, changing the test files was not mandatory. As this PR only modify how the SLD are written (and not read), and as the test to read are done like that: geostyler-style -> sld -> geostyler-style, the tests were not failing.

Most of the example was already correct (using 'ogc:'). And on master we have a mix `Literal` and `ogc:Literal` (for example: https://github.com/geostyler/geostyler-sld-parser/blob/main/src/SldStyleParser.ts#L2752 )

Ideally, we should add a way to ensure that the produced sld (xml) is correct regarding the sld schemas. But that's more a topic for a code sprint.

With this fix, my SLD is working in Geoserver, in version 1.0.0 as in version 1.1.0 :partying_face:  


