### PR TITLE
fix: write AnchorPoint before Displacement in PointPlacement (#1125)

### DIFF
--- a/data/slds/1.0/point_styledLabel_elementOrder.sld
+++ b/data/slds/1.0/point_styledLabel_elementOrder.sld
@@ -24,6 +24,10 @@
             </Font>
             <LabelPlacement>
               <PointPlacement>
+                <AnchorPoint>
+                  <AnchorPointX>1</AnchorPointX>
+                  <AnchorPointY>1</AnchorPointY>
+                </AnchorPoint>
                 <Displacement>
                   <DisplacementX>0</DisplacementX>
                   <DisplacementY>5</DisplacementY>

--- a/data/slds/1.1/point_styledLabel_elementOrder.sld
+++ b/data/slds/1.1/point_styledLabel_elementOrder.sld
@@ -23,6 +23,10 @@
             </se:Font>
             <se:LabelPlacement>
               <se:PointPlacement>
+                <se:AnchorPoint>
+                  <se:AnchorPointX>1</se:AnchorPointX>
+                  <se:AnchorPointY>1</se:AnchorPointY>
+                </se:AnchorPoint>
                 <se:Displacement>
                   <se:DisplacementX>0</se:DisplacementX>
                   <se:DisplacementY>5</se:DisplacementY>

--- a/data/styles/point_styledLabel_elementOrder.ts
+++ b/data/styles/point_styledLabel_elementOrder.ts
@@ -10,6 +10,7 @@ const pointStyledLabel: Style = {
       label: 'prefix: {{name}}{{title}} entity',
       font: ['Arial'],
       size: 12,
+      anchor: 'top-right',
       offset: [0, -5],
       haloColor: '#000000',
       haloWidth: 5,

--- a/src/SldStyleParser.ts
+++ b/src/SldStyleParser.ts
@@ -2627,20 +2627,8 @@ export class SldStyleParser implements StyleParser<string> {
       || textSymbolizer.rotate !== undefined
       || textSymbolizer.placement === 'point'
     ) {
+      // The SLD schema requires the sequence AnchorPoint, Displacement, Rotation.
       const pointPlacement: any = [];
-      if (textSymbolizer.offset) {
-        pointPlacement.push({
-          [Displacement]: [{
-            [DisplacementX]: [{
-              '#text': textSymbolizer.offset[0].toString()
-            }]
-          }, {
-            [DisplacementY]: [{
-              '#text': (-textSymbolizer.offset[1]).toString()
-            }]
-          }]
-        });
-      }
       if (textSymbolizer.anchor) {
         pointPlacement.push({
           [AnchorPoint]: [{
@@ -2650,6 +2638,19 @@ export class SldStyleParser implements StyleParser<string> {
           }, {
             [AnchorPointY]: [{
               '#text': this.getSldAnchorPointFromAnchor(textSymbolizer.anchor, 'y').toString()
+            }]
+          }]
+        });
+      }
+      if (textSymbolizer.offset) {
+        pointPlacement.push({
+          [Displacement]: [{
+            [DisplacementX]: [{
+              '#text': textSymbolizer.offset[0].toString()
+            }]
+          }, {
+            [DisplacementY]: [{
+              '#text': (-textSymbolizer.offset[1]).toString()
             }]
           }]
         });


### PR DESCRIPTION
Fixes #1125

`PointPlacement` children were written as `Displacement, AnchorPoint`, but the SLD 1.0.0 / SE 1.1.0 schemas require the sequence `AnchorPoint, Displacement, Rotation`. Any style combining `anchor` and `offset` produced SLD that fails XSD validation (GeoServer tolerates it, strict validators and some QGIS paths do not).

### Changes

- Swap the push order in `getSldTextSymbolizerFromTextSymbolizer` so `AnchorPoint` is written before `Displacement` (`Rotation` was already last).
- Extend the `point_styledLabel_elementOrder` fixtures (style + 1.0 + 1.1 SLDs) with an anchor, so the exact-match write tests and the read tests now lock in the correct order for both SLD versions. No previous fixture combined `anchor` and `offset`, which is why this went unnoticed.

### Verification

- Output of the issue repro now validates with `xmllint --schema` against the official SLD 1.0.0 XSD (it fails on `main`).
- Reading is unaffected: children are looked up by name, so SLDs written by earlier versions still parse fine.